### PR TITLE
fix: rename oauth_credentials.json to oauth_creds.json for Gemini CLI compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Each profile gets its own `$HOME` and `$CODEX_HOME` with symlinks to your real `
 |------|--------------|---------------|
 | **Claude Code** | OAuth: `~/.claude.json` + `~/.config/claude-code/auth.json` • API key: `~/.claude/settings.json` | `/login` in CLI |
 | **Codex CLI** | `~/.codex/auth.json` (file store enforced) | `codex login` (or `--device-auth`) |
-| **Gemini CLI** | OAuth: `~/.gemini/settings.json` (+ `oauth_credentials.json`) • API key: `~/.gemini/.env` | `gemini` interactive |
+| **Gemini CLI** | OAuth: `~/.gemini/settings.json` (+ `oauth_creds.json`) • API key: `~/.gemini/.env` | `gemini` interactive |
 
 ### Claude Code (Claude Max)
 
@@ -182,7 +182,7 @@ Each profile gets its own `$HOME` and `$CODEX_HOME` with symlinks to your real `
 
 **Auth Files:**
 - `~/.gemini/settings.json`
-- `~/.gemini/oauth_credentials.json` (OAuth cache)
+- `~/.gemini/oauth_creds.json` (OAuth cache)
 - `~/.gemini/.env` (API key mode)
 
 **Login Command:** Start `gemini`, select "Login with Google" or use `/auth` to switch modes

--- a/cmd/caam/cmd/detect.go
+++ b/cmd/caam/cmd/detect.go
@@ -188,7 +188,7 @@ func getAgentSpecs() []AgentSpec {
 			AuthPaths: func() []PathSpec {
 				return []PathSpec{
 					{filepath.Join(homeDir, ".gemini", "settings.json"), "OAuth/settings"},
-					{filepath.Join(homeDir, ".gemini", "oauth_credentials.json"), "OAuth credentials"},
+					{filepath.Join(homeDir, ".gemini", "oauth_creds.json"), "OAuth credentials"},
 					{filepath.Join(homeDir, ".gemini", ".env"), "API key (env mode)"},
 				}
 			},

--- a/cmd/caam/cmd/refresh.go
+++ b/cmd/caam/cmd/refresh.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/authfile"
 	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/config"
 	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/health"
 	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/refresh"
@@ -312,6 +313,8 @@ func loadExpiryInfo(tool, profile string) (*health.ExpiryInfo, error) {
 	case "codex":
 		return health.ParseCodexExpiry(filepath.Join(vaultPath, "auth.json"))
 	case "gemini":
+		// Migrate legacy vault filename before reading.
+		_ = authfile.MigrateGeminiVaultDir(vaultPath)
 		return health.ParseGeminiExpiry(vaultPath)
 	default:
 		return nil, fmt.Errorf("refresh not supported for tool: %s", tool)

--- a/cmd/caam/cmd/refresh_test.go
+++ b/cmd/caam/cmd/refresh_test.go
@@ -149,7 +149,7 @@ func TestRefreshSingle_SkipsWhenUnsupported(t *testing.T) {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
 
-	// No oauth_credentials.json present, so refresh should be treated as unsupported and skipped.
+	// No oauth_creds.json present, so refresh should be treated as unsupported and skipped.
 	if err := refreshSingle(context.Background(), "gemini", "main", 10*time.Minute, false, false, true); err != nil {
 		t.Fatalf("refreshSingle() error = %v", err)
 	}
@@ -209,7 +209,7 @@ func TestRefreshSingle_GeminiUpdatesSettings(t *testing.T) {
 	if err != nil {
 		t.Fatalf("MarshalIndent() error = %v", err)
 	}
-	oauthCredPath := filepath.Join(profileDir, "oauth_credentials.json")
+	oauthCredPath := filepath.Join(profileDir, "oauth_creds.json")
 	if err := os.WriteFile(oauthCredPath, adcRaw, 0600); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}

--- a/cmd/caam/cmd/root.go
+++ b/cmd/caam/cmd/root.go
@@ -243,6 +243,8 @@ func buildProfileHealth(tool, profileName string) *health.ProfileHealth {
 		authPath := filepath.Join(vaultPath, "auth.json")
 		expInfo, err = health.ParseCodexExpiry(authPath)
 	case "gemini":
+		// Migrate legacy vault filename before reading.
+		_ = authfile.MigrateGeminiVaultDir(vaultPath)
 		expInfo, err = health.ParseGeminiExpiry(vaultPath)
 	}
 
@@ -283,9 +285,11 @@ func getVaultIdentity(tool, profileName string) *identity.Identity {
 		normalizeIdentityPlan(id)
 		return id
 	case "gemini":
+		// Migrate legacy vault filename before reading.
+		_ = authfile.MigrateGeminiVaultDir(vaultPath)
 		candidates := []string{
 			filepath.Join(vaultPath, "settings.json"),
-			filepath.Join(vaultPath, "oauth_credentials.json"),
+			filepath.Join(vaultPath, "oauth_creds.json"),
 		}
 		for _, path := range candidates {
 			id, err := identity.ExtractFromGeminiConfig(path)

--- a/docs/DISTRIBUTED_AUTH_RECOVERY.md
+++ b/docs/DISTRIBUTED_AUTH_RECOVERY.md
@@ -132,7 +132,7 @@ Uses fsnotify to watch auth file changes:
 - `~/.config/claude-code/auth.json`
 - `~/.codex/auth.json`
 - `~/.gemini/settings.json`
-- `~/.gemini/oauth_credentials.json`
+- `~/.gemini/oauth_creds.json`
 
 On file change:
 1. Debounce (wait 500ms for writes to settle)

--- a/docs/FEATURE_PLAN_2025Q1.md
+++ b/docs/FEATURE_PLAN_2025Q1.md
@@ -125,7 +125,7 @@ This creates unnecessary friction in the critical first-use experience.
 **Why:**
 - Claude: `~/.claude.json`, `~/.config/claude-code/auth.json`, `~/.claude/settings.json` (apiKeyHelper)
 - Codex: `~/.codex/auth.json` (file store enforced)
-- Gemini: `~/.gemini/settings.json`, `~/.gemini/oauth_credentials.json`, `~/.gemini/.env` (API key)
+- Gemini: `~/.gemini/settings.json`, `~/.gemini/oauth_creds.json`, `~/.gemini/.env` (API key)
 - Detection enables import and status reporting
 
 **Design Decisions:**

--- a/docs/SMART_PROFILE_MANAGEMENT.md
+++ b/docs/SMART_PROFILE_MANAGEMENT.md
@@ -467,7 +467,7 @@ Options considered:
 ```
 
 ### Google Gemini
-- Auth files: `~/.gemini/settings.json`, `~/.gemini/oauth_credentials.json`
+- Auth files: `~/.gemini/settings.json`, `~/.gemini/oauth_creds.json`
 - API key mode: `~/.gemini/.env`
 - Vertex AI ADC: `~/.config/gcloud/application_default_credentials.json`
 - Token endpoint: `https://oauth2.googleapis.com/token`

--- a/internal/api/handlers.go
+++ b/internal/api/handlers.go
@@ -485,9 +485,11 @@ func (h *Handlers) getProfileIdentity(tool, name string) *identity.Identity {
 	case "claude":
 		id, err = identity.ExtractFromClaudeCredentials(vaultPath + "/.credentials.json")
 	case "gemini":
+		// Migrate legacy vault filename before reading.
+		_ = authfile.MigrateGeminiVaultDir(vaultPath)
 		id, err = identity.ExtractFromGeminiConfig(vaultPath + "/settings.json")
 		if err != nil {
-			id, err = identity.ExtractFromGeminiConfig(vaultPath + "/oauth_credentials.json")
+			id, err = identity.ExtractFromGeminiConfig(vaultPath + "/oauth_creds.json")
 		}
 	}
 

--- a/internal/authfile/authfile.go
+++ b/internal/authfile/authfile.go
@@ -142,7 +142,7 @@ func GeminiAuthFiles() AuthFileSet {
 			// Additional auth files that may store tokens
 			{
 				Tool:        "gemini",
-				Path:        filepath.Join(geminiHome, "oauth_credentials.json"),
+				Path:        filepath.Join(geminiHome, "oauth_creds.json"),
 				Description: "Gemini CLI OAuth credentials cache",
 				Required:    false,
 			},
@@ -480,6 +480,34 @@ func (v *Vault) BackupOriginal(fileSet AuthFileSet) (bool, error) {
 	return true, nil
 }
 
+// MigrateGeminiVaultDir renames oauth_credentials.json to oauth_creds.json in a
+// vault profile directory if the old name exists and the new name does not.
+// CAAM previously stored "oauth_credentials.json" but Gemini CLI reads "oauth_creds.json".
+// This is a no-op if the directory already has the new name or has no OAuth file.
+func MigrateGeminiVaultDir(dir string) error {
+	oldName := filepath.Join(dir, "oauth_credentials.json")
+	newName := filepath.Join(dir, "oauth_creds.json")
+	if _, err := os.Stat(oldName); err != nil {
+		if os.IsNotExist(err) {
+			return nil // old file doesn't exist, nothing to migrate
+		}
+		return err // permission or I/O error
+	}
+	if _, err := os.Stat(newName); err == nil {
+		// New file already exists; remove legacy file to avoid confusion.
+		_ = os.Remove(oldName)
+		return nil
+	}
+	if err := os.Rename(oldName, newName); err != nil {
+		// Handle race: another process may have completed the migration.
+		if _, statErr := os.Stat(newName); statErr == nil {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
 // Restore copies backed-up auth files to their original locations.
 func (v *Vault) Restore(fileSet AuthFileSet, profile string) error {
 	profileDir, err := v.safeProfileDir(fileSet.Tool, profile)
@@ -489,6 +517,13 @@ func (v *Vault) Restore(fileSet AuthFileSet, profile string) error {
 
 	if _, err := os.Stat(profileDir); os.IsNotExist(err) {
 		return fmt.Errorf("profile %s/%s not found in vault; run 'caam ls %s' to see available profiles", fileSet.Tool, profile, fileSet.Tool)
+	}
+
+	// Migrate legacy Gemini OAuth filename in vault.
+	if fileSet.Tool == "gemini" {
+		if err := MigrateGeminiVaultDir(profileDir); err != nil {
+			return fmt.Errorf("vault migration (oauth_credentials.json -> oauth_creds.json): %w", err)
+		}
 	}
 
 	restored := 0

--- a/internal/authfile/authfile_test.go
+++ b/internal/authfile/authfile_test.go
@@ -409,6 +409,111 @@ func TestVaultRestore(t *testing.T) {
 	})
 }
 
+func TestMigrateGeminiVaultDir(t *testing.T) {
+	t.Run("renames old file to new", func(t *testing.T) {
+		dir := t.TempDir()
+		oldPath := filepath.Join(dir, "oauth_credentials.json")
+		newPath := filepath.Join(dir, "oauth_creds.json")
+		if err := os.WriteFile(oldPath, []byte(`{"client_id":"x"}`), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if err := MigrateGeminiVaultDir(dir); err != nil {
+			t.Fatalf("MigrateGeminiVaultDir() error = %v", err)
+		}
+		if _, err := os.Stat(newPath); err != nil {
+			t.Errorf("new file should exist: %v", err)
+		}
+		if _, err := os.Stat(oldPath); !os.IsNotExist(err) {
+			t.Errorf("old file should not exist after rename")
+		}
+	})
+
+	t.Run("no-op when new file already exists", func(t *testing.T) {
+		dir := t.TempDir()
+		oldPath := filepath.Join(dir, "oauth_credentials.json")
+		newPath := filepath.Join(dir, "oauth_creds.json")
+		if err := os.WriteFile(oldPath, []byte(`old`), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(newPath, []byte(`new`), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if err := MigrateGeminiVaultDir(dir); err != nil {
+			t.Fatalf("MigrateGeminiVaultDir() error = %v", err)
+		}
+		data, _ := os.ReadFile(newPath)
+		if string(data) != "new" {
+			t.Errorf("new file should be unchanged, got %q", data)
+		}
+	})
+
+	t.Run("no-op when no old file", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := MigrateGeminiVaultDir(dir); err != nil {
+			t.Fatalf("MigrateGeminiVaultDir() error = %v", err)
+		}
+	})
+
+	t.Run("idempotent", func(t *testing.T) {
+		dir := t.TempDir()
+		oldPath := filepath.Join(dir, "oauth_credentials.json")
+		newPath := filepath.Join(dir, "oauth_creds.json")
+		if err := os.WriteFile(oldPath, []byte(`{"client_id":"x"}`), 0600); err != nil {
+			t.Fatal(err)
+		}
+		// Run twice
+		if err := MigrateGeminiVaultDir(dir); err != nil {
+			t.Fatal(err)
+		}
+		if err := MigrateGeminiVaultDir(dir); err != nil {
+			t.Fatal(err)
+		}
+		data, _ := os.ReadFile(newPath)
+		if string(data) != `{"client_id":"x"}` {
+			t.Errorf("content should survive double migration, got %q", data)
+		}
+	})
+}
+
+func TestVaultRestore_MigratesGeminiFilename(t *testing.T) {
+	tmpDir := t.TempDir()
+	vaultDir := filepath.Join(tmpDir, "vault")
+	authDir := filepath.Join(tmpDir, "auth")
+
+	// Create vault profile with OLD filename
+	profileDir := filepath.Join(vaultDir, "gemini", "testprofile")
+	if err := os.MkdirAll(profileDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	oldContent := []byte(`{"client_id":"test","client_secret":"s","refresh_token":"r"}`)
+	if err := os.WriteFile(filepath.Join(profileDir, "oauth_credentials.json"), oldContent, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	v := NewVault(vaultDir)
+	authFile := filepath.Join(authDir, ".gemini", "oauth_creds.json")
+	fileSet := AuthFileSet{
+		Tool: "gemini",
+		Files: []AuthFileSpec{
+			{Tool: "gemini", Path: authFile, Required: false},
+		},
+		AllowOptionalOnly: true,
+	}
+
+	if err := v.Restore(fileSet, "testprofile"); err != nil {
+		t.Fatalf("Restore() error = %v", err)
+	}
+
+	// Verify the file was restored to the NEW name location
+	restored, err := os.ReadFile(authFile)
+	if err != nil {
+		t.Fatalf("restored file should exist at new path: %v", err)
+	}
+	if string(restored) != string(oldContent) {
+		t.Errorf("restored content = %q, want %q", restored, oldContent)
+	}
+}
+
 func TestVaultList(t *testing.T) {
 	t.Run("empty vault returns empty list", func(t *testing.T) {
 		tmpDir := t.TempDir()

--- a/internal/bundle/import.go
+++ b/internal/bundle/import.go
@@ -466,7 +466,7 @@ func (i *VaultImporter) compareFreshness(provider, profile, localPath, bundlePat
 	case "codex":
 		authFileNames = []string{"auth.json"}
 	case "gemini":
-		authFileNames = []string{"settings.json", "oauth_credentials.json"}
+		authFileNames = []string{"settings.json", "oauth_creds.json", "oauth_credentials.json"}
 	default:
 		return nil, nil
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -707,6 +707,8 @@ func (d *Daemon) getProfileHealth(provider, profile string) *health.ProfileHealt
 	case "codex":
 		expiryInfo, err = health.ParseCodexExpiry(filepath.Join(vaultPath, "auth.json"))
 	case "gemini":
+		// Migrate legacy vault filename before reading.
+		_ = authfile.MigrateGeminiVaultDir(vaultPath)
 		expiryInfo, err = health.ParseGeminiExpiry(vaultPath)
 	}
 

--- a/internal/daemon/pool_refresher.go
+++ b/internal/daemon/pool_refresher.go
@@ -56,6 +56,8 @@ func (r *PoolRefresher) getTokenExpiry(provider, profile string) (time.Time, err
 	case "codex":
 		expiryInfo, err = health.ParseCodexExpiry(filepath.Join(vaultPath, "auth.json"))
 	case "gemini":
+		// Migrate legacy vault filename before reading.
+		_ = authfile.MigrateGeminiVaultDir(vaultPath)
 		expiryInfo, err = health.ParseGeminiExpiry(vaultPath)
 	default:
 		return time.Time{}, fmt.Errorf("unknown provider: %s", provider)

--- a/internal/discovery/watcher.go
+++ b/internal/discovery/watcher.go
@@ -474,7 +474,7 @@ func (w *Watcher) extractIdentity(provider, path string) (*identity.Identity, er
 		return nil, fmt.Errorf("codex auth not found")
 
 	case "gemini":
-		if strings.HasSuffix(path, "settings.json") || strings.HasSuffix(path, "oauth_credentials.json") {
+		if strings.HasSuffix(path, "settings.json") || strings.HasSuffix(path, "oauth_creds.json") {
 			return identity.ExtractFromGeminiConfig(path)
 		}
 		// Check default location

--- a/internal/health/expiry.go
+++ b/internal/health/expiry.go
@@ -248,7 +248,7 @@ func ParseCodexExpiry(authPath string) (*ExpiryInfo, error) {
 //
 // Gemini CLI stores auth in:
 //   - ~/.gemini/settings.json
-//   - ~/.gemini/oauth_credentials.json (optional)
+//   - ~/.gemini/oauth_creds.json (optional)
 //
 // Note: Google OAuth tokens via ADC may not include expiry in the file itself.
 // The expiry is typically short-lived and requires refresh.
@@ -272,8 +272,8 @@ func ParseGeminiExpiry(authDir string) (*ExpiryInfo, error) {
 		return info, nil
 	}
 
-	// Try oauth_credentials.json
-	oauthPath := filepath.Join(authDir, "oauth_credentials.json")
+	// Try oauth_creds.json
+	oauthPath := filepath.Join(authDir, "oauth_creds.json")
 	info, err = parseOAuthFile(oauthPath)
 	if err == nil {
 		info.Source = oauthPath

--- a/internal/health/expiry_test.go
+++ b/internal/health/expiry_test.go
@@ -397,12 +397,12 @@ func TestParseGeminiExpiry(t *testing.T) {
 	}
 }
 
-func TestParseGeminiExpiry_OAuthCredentialsFileWithoutSettingsReturnsNoExpiry(t *testing.T) {
+func TestParseGeminiExpiry_OAuthCredsFileWithoutSettingsReturnsNoExpiry(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// oauth_credentials.json exists but contains no expiry/refresh token.
+	// oauth_creds.json exists but contains no expiry/refresh token.
 	// This should surface as ErrNoExpiry (not ErrNoAuthFile).
-	oauthPath := filepath.Join(tmpDir, "oauth_credentials.json")
+	oauthPath := filepath.Join(tmpDir, "oauth_creds.json")
 	if err := os.WriteFile(oauthPath, []byte(`{}`), 0600); err != nil {
 		t.Fatalf("failed to write test file: %v", err)
 	}

--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -133,7 +133,7 @@ func (p *Profile) LoadIdentity() {
 	case "gemini":
 		candidates := []string{
 			filepath.Join(p.HomePath(), ".gemini", "settings.json"),
-			filepath.Join(p.HomePath(), ".gemini", "oauth_credentials.json"),
+			filepath.Join(p.HomePath(), ".gemini", "oauth_creds.json"),
 		}
 		if strings.EqualFold(p.AuthMode, "vertex-adc") {
 			candidates = append(candidates, filepath.Join(p.BasePath, "gcloud", "application_default_credentials.json"))

--- a/internal/provider/gemini/gemini.go
+++ b/internal/provider/gemini/gemini.go
@@ -87,7 +87,7 @@ func (p *Provider) AuthFiles() []provider.AuthFileSpec {
 			Required:    true,
 		},
 		{
-			Path:        filepath.Join(geminiHome(), "oauth_credentials.json"),
+			Path:        filepath.Join(geminiHome(), "oauth_creds.json"),
 			Description: "Gemini CLI OAuth credentials cache",
 			Required:    false,
 		},
@@ -297,7 +297,8 @@ func (p *Provider) Logout(ctx context.Context, prof *profile.Profile) error {
 	paths := []string{
 		filepath.Join(geminiDir, ".env"),
 		filepath.Join(geminiDir, "settings.json"),
-		filepath.Join(geminiDir, "oauth_credentials.json"),
+		filepath.Join(geminiDir, "oauth_creds.json"),
+		filepath.Join(geminiDir, "oauth_credentials.json"), // legacy CAAM filename
 	}
 	for _, path := range paths {
 		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
@@ -343,7 +344,7 @@ func (p *Provider) Status(ctx context.Context, prof *profile.Profile) (*provider
 	default:
 		// Check for cached Google login tokens
 		settingsPath := filepath.Join(prof.HomePath(), ".gemini", "settings.json")
-		oauthPath := filepath.Join(prof.HomePath(), ".gemini", "oauth_credentials.json")
+		oauthPath := filepath.Join(prof.HomePath(), ".gemini", "oauth_creds.json")
 		if _, err := os.Stat(settingsPath); err == nil {
 			status.LoggedIn = true
 		} else if _, err := os.Stat(oauthPath); err == nil {
@@ -402,7 +403,7 @@ func xdgConfigHome() string {
 // DetectExistingAuth detects existing Gemini authentication files in standard locations.
 // Locations checked:
 // - ~/.gemini/settings.json (main settings with OAuth state)
-// - ~/.gemini/oauth_credentials.json (OAuth credentials cache)
+// - ~/.gemini/oauth_creds.json (OAuth credentials cache)
 // - ~/.gemini/.env (API key)
 // - ~/.config/gcloud/application_default_credentials.json (Vertex AI ADC)
 func (p *Provider) DetectExistingAuth() (*provider.AuthDetection, error) {
@@ -449,7 +450,7 @@ func (p *Provider) DetectExistingAuth() (*provider.AuthDetection, error) {
 				},
 			},
 			{
-				path:        filepath.Join(baseDir, "oauth_credentials.json"),
+				path:        filepath.Join(baseDir, "oauth_creds.json"),
 				description: "Gemini CLI OAuth credentials cache" + suffix,
 				validator: func(data []byte) (bool, string) {
 					var parsed map[string]interface{}
@@ -739,7 +740,7 @@ func (p *Provider) validateTokenPassive(ctx context.Context, prof *profile.Profi
 	// Check auth files exist
 	geminiDir := filepath.Join(prof.HomePath(), ".gemini")
 	settingsPath := filepath.Join(geminiDir, "settings.json")
-	oauthPath := filepath.Join(geminiDir, "oauth_credentials.json")
+	oauthPath := filepath.Join(geminiDir, "oauth_creds.json")
 	envPath := filepath.Join(geminiDir, ".env")
 
 	settingsExists := fileExistsGemini(settingsPath)
@@ -778,19 +779,19 @@ func (p *Provider) validateTokenPassive(ctx context.Context, prof *profile.Profi
 		return result, nil
 	}
 
-	// Check oauth_credentials.json if it exists (has expiry info)
+	// Check oauth_creds.json if it exists (has expiry info)
 	if oauthExists {
 		data, err := os.ReadFile(oauthPath)
 		if err != nil {
 			result.Valid = false
-			result.Error = fmt.Sprintf("cannot read oauth_credentials.json: %v", err)
+			result.Error = fmt.Sprintf("cannot read oauth_creds.json: %v", err)
 			return result, nil
 		}
 
 		var oauthData map[string]interface{}
 		if err := json.Unmarshal(data, &oauthData); err != nil {
 			result.Valid = false
-			result.Error = fmt.Sprintf("invalid JSON in oauth_credentials.json: %v", err)
+			result.Error = fmt.Sprintf("invalid JSON in oauth_creds.json: %v", err)
 			return result, nil
 		}
 

--- a/internal/provider/gemini/gemini_test.go
+++ b/internal/provider/gemini/gemini_test.go
@@ -113,16 +113,16 @@ func TestAuthFiles(t *testing.T) {
 		}
 	})
 
-	t.Run("second file is oauth_credentials.json and optional", func(t *testing.T) {
+	t.Run("second file is oauth_creds.json and optional", func(t *testing.T) {
 		p := New()
 		files := p.AuthFiles()
 
 		file := files[1]
-		if !strings.HasSuffix(file.Path, "oauth_credentials.json") {
-			t.Errorf("AuthFiles()[1].Path = %q, should end with oauth_credentials.json", file.Path)
+		if !strings.HasSuffix(file.Path, "oauth_creds.json") {
+			t.Errorf("AuthFiles()[1].Path = %q, should end with oauth_creds.json", file.Path)
 		}
 		if file.Required {
-			t.Error("oauth_credentials.json should be optional")
+			t.Error("oauth_creds.json should be optional")
 		}
 	})
 
@@ -980,13 +980,13 @@ func TestDetectExistingAuth(t *testing.T) {
 		}
 	})
 
-	t.Run("detects oauth_credentials.json", func(t *testing.T) {
+	t.Run("detects oauth_creds.json", func(t *testing.T) {
 		home, _ := setupEnv(t)
 		p := New()
 
 		geminiDir := filepath.Join(home, ".gemini")
 		os.MkdirAll(geminiDir, 0700)
-		path := filepath.Join(geminiDir, "oauth_credentials.json")
+		path := filepath.Join(geminiDir, "oauth_creds.json")
 		writeJSON(t, path, map[string]interface{}{"access_token": "valid"})
 
 		detection, err := p.DetectExistingAuth()

--- a/internal/refresh/gemini.go
+++ b/internal/refresh/gemini.go
@@ -124,7 +124,7 @@ func UpdateGeminiAuth(path string, resp *GoogleTokenResponse) error {
 		updated = true
 	}
 
-	// If no nested structure found, or if we want to support flat files too (like oauth_credentials.json),
+	// If no nested structure found, or if we want to support flat files too (like oauth_creds.json),
 	// we check if we should update the top level.
 	// If we updated a nested object, we shouldn't update top level unless it ALSO has token fields.
 	// But usually it's one or the other.

--- a/internal/refresh/refresh.go
+++ b/internal/refresh/refresh.go
@@ -127,13 +127,16 @@ func refreshCodex(ctx context.Context, vaultPath string) error {
 }
 
 func refreshGemini(ctx context.Context, provider, profile string, store *health.Storage, vaultPath string) error {
+	// Migrate legacy vault filename before reading.
+	_ = authfile.MigrateGeminiVaultDir(vaultPath)
+
 	info, err := health.ParseGeminiExpiry(vaultPath)
 	if err != nil {
 		return fmt.Errorf("parse gemini auth: %w", err)
 	}
 
 	settingsPath := filepath.Join(vaultPath, "settings.json")
-	oauthCredPath := filepath.Join(vaultPath, "oauth_credentials.json")
+	oauthCredPath := filepath.Join(vaultPath, "oauth_creds.json")
 
 	var adc *ADC
 	for _, candidate := range []string{oauthCredPath, settingsPath} {
@@ -152,7 +155,7 @@ func refreshGemini(ctx context.Context, provider, profile string, store *health.
 	}
 
 	if adc == nil {
-		return &UnsupportedError{Provider: provider, Reason: "missing oauth client credentials (expected oauth_credentials.json with client_id/client_secret/refresh_token)"}
+		return &UnsupportedError{Provider: provider, Reason: "missing oauth client credentials (expected oauth_creds.json with client_id/client_secret/refresh_token)"}
 	}
 
 	resp, err := RefreshGeminiToken(ctx, adc.ClientID, adc.ClientSecret, adc.RefreshToken)

--- a/internal/refresh/refresh_extended_test.go
+++ b/internal/refresh/refresh_extended_test.go
@@ -123,8 +123,8 @@ func TestRefreshProfile_Gemini_Extended(t *testing.T) {
 	initialSettings := `{"accessToken": "old-gemini-access"}`
 	require.NoError(t, os.WriteFile(settingsPath, []byte(initialSettings), 0600))
 	
-	// Gemini needs oauth_credentials.json for client info
-	credsPath := filepath.Join(profileDir, "oauth_credentials.json")
+	// Gemini needs oauth_creds.json for client info
+	credsPath := filepath.Join(profileDir, "oauth_creds.json")
 	credsContent := `{"client_id": "test-id", "client_secret": "test-secret", "refresh_token": "gemini-refresh"}`
 	require.NoError(t, os.WriteFile(credsPath, []byte(credsContent), 0600))
 	

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -2053,9 +2053,11 @@ func vaultIdentityEmail(provider, profileDir string) string {
 	case "claude":
 		id, _ = identity.ExtractFromClaudeCredentials(filepath.Join(profileDir, ".credentials.json"))
 	case "gemini":
+		// Migrate legacy vault filename before reading.
+		_ = authfile.MigrateGeminiVaultDir(profileDir)
 		id, _ = identity.ExtractFromGeminiConfig(filepath.Join(profileDir, "settings.json"))
 		if id == nil {
-			id, _ = identity.ExtractFromGeminiConfig(filepath.Join(profileDir, "oauth_credentials.json"))
+			id, _ = identity.ExtractFromGeminiConfig(filepath.Join(profileDir, "oauth_creds.json"))
 		}
 	}
 	if id == nil {

--- a/internal/warnings/warnings.go
+++ b/internal/warnings/warnings.go
@@ -143,6 +143,8 @@ func (c *Checker) checkVaultProfile(ctx context.Context, tool, profileName strin
 		authPath := filepath.Join(vaultPath, "auth.json")
 		expInfo, err = health.ParseCodexExpiry(authPath)
 	case "gemini":
+		// Migrate legacy vault filename before reading.
+		_ = authfile.MigrateGeminiVaultDir(vaultPath)
 		expInfo, err = health.ParseGeminiExpiry(vaultPath)
 	}
 


### PR DESCRIPTION
## Summary

Gemini CLI reads `oauth_creds.json` but CAAM stores/expects `oauth_credentials.json`, causing `caam activate gemini` to silently fail — credentials get saved under the wrong filename.

- Rename all hardcoded `oauth_credentials.json` filename references → `oauth_creds.json` (25 files)
- Add `MigrateGeminiVaultDir()` — race-safe, idempotent migration that auto-renames old files in vault directories, called at every vault read point
- Logout cleans up both new and legacy filenames
- Bundle import accepts both filenames for backward compatibility with older exports
- Full test coverage for migration scenarios (rename, no-op, idempotent, vault restore)

**Note:** The JSON key `"oauth_credentials"` inside `settings.json` content is intentionally preserved — it matches what Gemini CLI writes into its settings and is distinct from the filename.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] Manual testing with 2 Gemini accounts via `caam activate gemini` — confirmed working
- [x] Verified migration handles: old file only, new file only, both files, no files, concurrent callers