### PR TITLE
feat(cli): add --version flag (alias for `version` subcommand)

### DIFF
--- a/cmd/caam/cmd/root.go
+++ b/cmd/caam/cmd/root.go
@@ -77,7 +77,8 @@ func getDB() (*caamdb.DB, error) {
 
 // rootCmd represents the base command.
 var rootCmd = &cobra.Command{
-	Use:   "caam",
+	Use:     "caam",
+	Version: version.Info(),
 	Short: "Coding Agent Account Manager - instant auth switching",
 	Long: `caam (Coding Agent Account Manager) manages auth files for AI coding CLIs
 to enable instant account switching for "all you can eat" subscription plans
@@ -541,6 +542,9 @@ func truncateDescription(desc string, maxLen int) string {
 }
 
 func init() {
+	// Make `caam --version` and `caam -v` print the same string as `caam version`.
+	rootCmd.SetVersionTemplate("{{.Version}}\n")
+
 	// Core commands (auth file swapping - PRIMARY)
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(backupCmd)


### PR DESCRIPTION
## Summary

Adds a `--version` (and `-v`) flag to `caam`, output matches the existing `caam version` subcommand byte-for-byte. Backward compatible — `caam version` is unchanged.

## Why

Tools that auto-detect installed CLIs commonly probe with `<tool> --version` — this is Cobra's default convention and the de-facto standard across the Go CLI ecosystem. caam currently only supports `caam version` as a subcommand, so probes get back:

```
$ caam --version
Error: unknown flag: --version
```

This causes spurious *"caam not responding"* warnings in tools like [`ntm`](https://github.com/Dicklesworthstone/ntm)'s `deps -v` check (and any other tool following the same convention). The binary works fine — the probe convention just doesn't match.

## Changes

`cmd/caam/cmd/root.go`:

1. Set `rootCmd.Version = version.Info()` — Cobra automatically wires `--version` / `-v` flags when this is set.
2. `rootCmd.SetVersionTemplate("{{.Version}}\n")` — Cobra's default template prefixes output with the command name, producing `caam version caam 0.1.11 ...` (double "caam"). This makes `--version`'s output match `caam version` exactly.

```diff
 var rootCmd = &cobra.Command{
-	Use:   "caam",
+	Use:     "caam",
+	Version: version.Info(),
 	Short: "Coding Agent Account Manager - instant auth switching",
```

```diff
 func init() {
+	// Make `caam --version` and `caam -v` print the same string as `caam version`.
+	rootCmd.SetVersionTemplate("{{.Version}}\n")
+
 	// Core commands (auth file swapping - PRIMARY)
 	rootCmd.AddCommand(versionCmd)
```

## Test plan

Built locally with `-X` ldflags injecting test version info; all three forms produce identical output:

```
$ caam version
caam 0.1.11 (7c604c4) built on 2026-04-26 with go1.24.4

$ caam --version
caam 0.1.11 (7c604c4) built on 2026-04-26 with go1.24.4

$ caam -v
caam 0.1.11 (7c604c4) built on 2026-04-26 with go1.24.4
```

- [x] Build succeeds
- [x] `caam --version` outputs version string
- [x] `caam -v` outputs version string
- [x] `caam version` subcommand still works (unchanged)
- [x] Output matches across all three forms

## Backward compatibility

Zero breakage:
- The `version` subcommand is untouched
- No existing flags affected
- No external API or behavior changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)