### PR TITLE
Track Claude desktop token cache for profile switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ No browser. No OAuth dance. No interruption to your flow state.
 ```mermaid
 flowchart LR
     subgraph System["Your System"]
-        A["~/.claude.json"]
+        A["~/.claude.json + Claude desktop token cache"]
         B["~/.codex/auth.json"]
         C["~/.gemini/settings.json"]
     end
@@ -213,7 +213,7 @@ wait
 
 | Tool | Auth Location | Login Command |
 |------|--------------|---------------|
-| **Claude Code** | OAuth: `~/.claude.json` + `~/.config/claude-code/auth.json` • API key: `~/.claude/settings.json` | `/login` in CLI |
+| **Claude Code** | OAuth: `~/.claude/.credentials.json` + `~/.claude.json` + `~/.config/claude-code/auth.json` + `~/Library/Application Support/Claude/config.json` • API key: `~/.claude/settings.json` | `/login` in CLI |
 | **Codex CLI** | `~/.codex/auth.json` (file store enforced) | `codex login` (or `--device-auth`) |
 | **Antigravity CLI** | OAuth: `~/.gemini/antigravity-cli/antigravity-oauth-token` (+ `~/.gemini/google_accounts.json`) | `agy` interactive (Google OAuth) |
 | **Gemini CLI** (legacy) | OAuth: `~/.gemini/settings.json` (+ `oauth_creds.json`) • API key: `~/.gemini/.env` | `gemini` interactive |
@@ -223,9 +223,11 @@ wait
 **Subscription:** Claude Max ($200/month)
 
 **Auth Files:**
-- `~/.claude.json` — Main authentication token
+- `~/.claude/.credentials.json` — Claude Code OAuth credentials when present
+- `~/.claude.json` — Claude Code session/account state
 - `~/.config/claude-code/auth.json` — Secondary auth data
 - `~/.claude/settings.json` — API key mode via `apiKeyHelper`
+- `~/Library/Application Support/Claude/config.json` — Claude Desktop encrypted OAuth token cache used by recent Claude Code builds on macOS
 
 **Login Command:** Inside Claude Code, type `/login`
 
@@ -663,6 +665,7 @@ claude "explain this authentication flow"
 │   │   ├── alice@gmail.com/
 │   │   │   ├── .claude.json        # Backed up auth
 │   │   │   ├── auth.json           # From ~/.config/claude-code/
+│   │   │   ├── config.json         # From ~/Library/Application Support/Claude/
 │   │   │   └── meta.json           # Timestamp, original paths
 │   │   └── bob@gmail.com/
 │   │       └── ...

--- a/docs/CLAUDE_AUTH_INVENTORY.json
+++ b/docs/CLAUDE_AUTH_INVENTORY.json
@@ -64,17 +64,18 @@
         "Primary: ~/.claude/.credentials.json (OAuth credentials)",
         "Optional: ~/.claude.json (legacy location)",
         "Optional: ~/.config/claude-code/auth.json",
-        "Optional: ~/.claude/settings.json (API key mode)"
+        "Optional: ~/.claude/settings.json (API key mode)",
+        "Optional: ~/Library/Application Support/Claude/config.json (encrypted desktop OAuth cache on macOS)"
       ],
       "observed_reality": [
         "~/.claude/.credentials.json IS the correct primary location",
         "~/.claude.json is legacy but may exist on older installs",
-        "File paths are CORRECT"
+        "Recent Claude Code builds on macOS can refresh ~/.claude.json from Claude Desktop oauth:tokenCache fields"
       ],
-      "classification": "correct",
-      "action": "No changes needed",
-      "risk_level": "low",
-      "user_visible": false
+      "classification": "updated",
+      "action": "Include Claude Desktop config in backup/restore, hash only oauth:tokenCache fields for matching, and scrub only those keys during clear/logout",
+      "risk_level": "medium",
+      "user_visible": true
     },
     {
       "id": "CLAUDE-004",

--- a/docs/CLAUDE_AUTH_INVENTORY.md
+++ b/docs/CLAUDE_AUTH_INVENTORY.md
@@ -73,15 +73,15 @@
 
 **File:** `internal/provider/claude/claude.go:88-113`
 **Function:** `AuthFiles`
-**Classification:** Correct
+**Classification:** Updated
 
 **Assumptions:**
 - Primary: `~/.claude/.credentials.json`
 - Optional: `~/.claude.json`, `~/.config/claude-code/auth.json`, `~/.claude/settings.json`
 
-**Reality:** File paths are correct.
+**Reality:** Recent Claude Code builds on macOS can also refresh `~/.claude.json` from Claude Desktop's encrypted OAuth cache in `~/Library/Application Support/Claude/config.json`. If CAAM swaps only `~/.claude.json`, Claude Code may rewrite it back to the account represented by the desktop token cache on startup.
 
-**Action:** No changes needed.
+**Action:** Include the Claude Desktop config in Claude backups/restores, hash only `oauth:tokenCache*` for profile matching, and scrub only those keys during clear/logout so unrelated desktop settings remain intact.
 
 ---
 

--- a/internal/authfile/authfile.go
+++ b/internal/authfile/authfile.go
@@ -77,6 +77,7 @@ func CodexAuthFiles() AuthFileSet {
 //   - ~/.claude.json (settings file - not auth, but backed up for completeness)
 //   - ~/.config/claude-code/auth.json (auth credentials; or $CLAUDE_CONFIG_DIR/auth.json)
 //   - ~/.claude/settings.json (user settings)
+//   - ~/Library/Application Support/Claude/config.json (encrypted desktop OAuth cache on macOS)
 func ClaudeAuthFiles() AuthFileSet {
 	homeDir, _ := os.UserHomeDir()
 	claudeConfigDir := os.Getenv("CLAUDE_CONFIG_DIR")
@@ -115,9 +116,19 @@ func ClaudeAuthFiles() AuthFileSet {
 				Description: "Claude Code user settings (apiKeyHelper / API key mode)",
 				Required:    false,
 			},
+			{
+				Tool:        "claude",
+				Path:        claudeDesktopConfigPath(homeDir),
+				Description: "Claude Desktop encrypted OAuth token cache",
+				Required:    false,
+			},
 		},
 		AllowOptionalOnly: true,
 	}
+}
+
+func claudeDesktopConfigPath(homeDir string) string {
+	return filepath.Join(homeDir, "Library", "Application Support", "Claude", "config.json")
 }
 
 // GeminiAuthFiles returns the auth files for Gemini CLI.
@@ -381,6 +392,15 @@ func (v *Vault) Backup(fileSet AuthFileSet, profile string) error {
 	var missingRequired []string
 	var originalPaths []string
 	for _, spec := range fileSet.Files {
+		if isClaudeDesktopConfig(fileSet.Tool, spec.Path) {
+			hasToken, err := claudeDesktopConfigHasToken(spec.Path)
+			if err != nil {
+				return err
+			}
+			if !hasToken {
+				continue
+			}
+		}
 		if _, err := os.Stat(spec.Path); os.IsNotExist(err) {
 			if spec.Required {
 				missingRequired = append(missingRequired, spec.Path)
@@ -916,6 +936,12 @@ func (v *Vault) ActiveProfile(fileSet AuthFileSet) (string, error) {
 	optionalHashes := make(map[string]string)
 	requiredFound := false
 	for _, spec := range fileSet.Files {
+		if isClaudeDesktopConfig(fileSet.Tool, spec.Path) {
+			hasToken, err := claudeDesktopConfigHasToken(spec.Path)
+			if err != nil || !hasToken {
+				continue
+			}
+		}
 		if _, err := os.Stat(spec.Path); os.IsNotExist(err) {
 			continue
 		}
@@ -983,6 +1009,12 @@ func (v *Vault) ActiveProfile(fileSet AuthFileSet) (string, error) {
 func HasAuthFiles(fileSet AuthFileSet) bool {
 	optionalFound := false
 	for _, spec := range fileSet.Files {
+		if isClaudeDesktopConfig(fileSet.Tool, spec.Path) {
+			hasToken, err := claudeDesktopConfigHasToken(spec.Path)
+			if err != nil || !hasToken {
+				continue
+			}
+		}
 		if _, err := os.Stat(spec.Path); err == nil {
 			if spec.Required {
 				return true
@@ -999,6 +1031,12 @@ func HasAuthFiles(fileSet AuthFileSet) bool {
 // ClearAuthFiles removes all auth files for a tool (logout).
 func ClearAuthFiles(fileSet AuthFileSet) error {
 	for _, spec := range fileSet.Files {
+		if isClaudeDesktopConfig(fileSet.Tool, spec.Path) {
+			if err := clearClaudeDesktopTokenCache(spec.Path); err != nil {
+				return err
+			}
+			continue
+		}
 		if err := os.Remove(spec.Path); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("remove %s: %w", spec.Path, err)
 		}
@@ -1006,7 +1044,94 @@ func ClearAuthFiles(fileSet AuthFileSet) error {
 	return nil
 }
 
+func isClaudeDesktopConfig(tool, path string) bool {
+	return tool == "claude" && filepath.Base(path) == "config.json" &&
+		strings.Contains(filepath.ToSlash(path), "/Library/Application Support/Claude/")
+}
+
+func claudeDesktopConfigHasToken(path string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read Claude desktop config: %w", err)
+	}
+
+	var root map[string]interface{}
+	if err := json.Unmarshal(data, &root); err != nil {
+		return false, fmt.Errorf("parse Claude desktop config: %w", err)
+	}
+
+	if _, ok := root["oauth:tokenCache"]; ok {
+		return true, nil
+	}
+	if _, ok := root["oauth:tokenCacheV2"]; ok {
+		return true, nil
+	}
+	return false, nil
+}
+
+func clearClaudeDesktopTokenCache(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read Claude desktop config: %w", err)
+	}
+
+	var root map[string]interface{}
+	if err := json.Unmarshal(data, &root); err != nil {
+		return fmt.Errorf("parse Claude desktop config: %w", err)
+	}
+
+	delete(root, "oauth:tokenCache")
+	delete(root, "oauth:tokenCacheV2")
+
+	updated, err := json.MarshalIndent(root, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal Claude desktop config: %w", err)
+	}
+	updated = append(updated, '\n')
+	if err := atomicWriteFile(path, updated, 0600); err != nil {
+		return fmt.Errorf("write Claude desktop config: %w", err)
+	}
+	return nil
+}
+
 // Helper functions
+
+func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+
+	dstFile, err := os.CreateTemp(dir, filepath.Base(path)+".tmp.*")
+	if err != nil {
+		return err
+	}
+	tmpPath := dstFile.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := dstFile.Write(data); err != nil {
+		dstFile.Close()
+		return err
+	}
+	if err := dstFile.Chmod(perm); err != nil {
+		dstFile.Close()
+		return err
+	}
+	if err := dstFile.Sync(); err != nil {
+		dstFile.Close()
+		return err
+	}
+	if err := dstFile.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}
 
 func copyFile(src, dst string) error {
 	// Ensure parent directory exists
@@ -1105,9 +1230,11 @@ func stableFileHash(tool, path string) (string, error) {
 //     refreshToken (the actual auth identity)
 //   - .claude.json: settings file with oauthAccount (identity) mixed with
 //     volatile fields like changelogLastFetched, numStartups, tipsHistory
+//   - config.json: Claude Desktop config with encrypted OAuth token cache fields
 //
 // For .credentials.json, we hash the accessToken and refreshToken.
 // For .claude.json, we hash the oauthAccount field only.
+// For Claude Desktop config.json, we hash oauth:tokenCache* fields only.
 // For other files (settings.json, auth.json), we fall back to whole-file hash.
 func stableClaudeHash(path string) (string, error) {
 	base := filepath.Base(path)
@@ -1117,6 +1244,11 @@ func stableClaudeHash(path string) (string, error) {
 		return hashClaudeCredentials(path)
 	case ".claude.json":
 		return hashClaudeSettings(path)
+	case "config.json":
+		if isClaudeDesktopConfig("claude", path) {
+			return hashClaudeDesktopConfig(path)
+		}
+		return hashFile(path)
 	default:
 		return hashFile(path)
 	}
@@ -1210,6 +1342,41 @@ func hashClaudeSettings(path string) (string, error) {
 
 	h := sha256.New()
 	h.Write([]byte("claude:settings:"))
+	h.Write(canonical)
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+func hashClaudeDesktopConfig(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+
+	var root map[string]interface{}
+	if err := json.Unmarshal(data, &root); err != nil {
+		return hashBytes(data), nil
+	}
+
+	identityFields := map[string]interface{}{}
+	for _, key := range []string{"oauth:tokenCache", "oauth:tokenCacheV2"} {
+		if v, exists := root[key]; exists {
+			identityFields[key] = v
+		}
+	}
+
+	if len(identityFields) == 0 {
+		h := sha256.New()
+		h.Write([]byte("claude:desktop-config:no-token-cache"))
+		return hex.EncodeToString(h.Sum(nil)), nil
+	}
+
+	canonical, err := json.Marshal(identityFields)
+	if err != nil {
+		return hashBytes(data), nil
+	}
+
+	h := sha256.New()
+	h.Write([]byte("claude:desktop-config:"))
 	h.Write(canonical)
 	return hex.EncodeToString(h.Sum(nil)), nil
 }

--- a/internal/authfile/authfile_test.go
+++ b/internal/authfile/authfile_test.go
@@ -1085,6 +1085,102 @@ func TestHasAuthFiles(t *testing.T) {
 	})
 }
 
+func TestClaudeAuthFilesIncludesDesktopTokenCache(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+
+	fileSet := ClaudeAuthFiles()
+	want := filepath.Join(home, "Library", "Application Support", "Claude", "config.json")
+
+	found := false
+	for _, spec := range fileSet.Files {
+		if spec.Path == want {
+			found = true
+			if spec.Required {
+				t.Error("Claude Desktop config should be optional")
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("ClaudeAuthFiles() missing Claude Desktop config path %q", want)
+	}
+}
+
+func TestClearAuthFilesScrubsClaudeDesktopTokenCache(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "Library", "Application Support", "Claude", "config.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{"darkMode":"light","oauth:tokenCache":"encrypted-v1","oauth:tokenCacheV2":"encrypted-v2"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	fileSet := AuthFileSet{
+		Tool: "claude",
+		Files: []AuthFileSpec{
+			{Tool: "claude", Path: configPath, Required: false},
+		},
+		AllowOptionalOnly: true,
+	}
+
+	if err := ClearAuthFiles(fileSet); err != nil {
+		t.Fatalf("ClearAuthFiles() error = %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("desktop config should be preserved: %v", err)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("desktop config should remain valid JSON: %v", err)
+	}
+	if _, ok := got["oauth:tokenCache"]; ok {
+		t.Error("oauth:tokenCache should be removed")
+	}
+	if _, ok := got["oauth:tokenCacheV2"]; ok {
+		t.Error("oauth:tokenCacheV2 should be removed")
+	}
+	if got["darkMode"] != "light" {
+		t.Errorf("non-auth desktop config should be preserved, got %v", got["darkMode"])
+	}
+	if HasAuthFiles(fileSet) {
+		t.Error("tokenless Claude Desktop config should not count as active auth")
+	}
+}
+
+func TestStableClaudeHashForDesktopConfigUsesOnlyTokenCache(t *testing.T) {
+	tmpDir := t.TempDir()
+	configA := filepath.Join(tmpDir, "a", "Library", "Application Support", "Claude", "config.json")
+	configB := filepath.Join(tmpDir, "b", "Library", "Application Support", "Claude", "config.json")
+	for _, path := range []string{configA, configB} {
+		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(configA, []byte(`{"darkMode":"light","oauth:tokenCacheV2":"same-token"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configB, []byte(`{"darkMode":"dark","windowState":{"x":10},"oauth:tokenCacheV2":"same-token"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	hashA, err := stableClaudeHash(configA)
+	if err != nil {
+		t.Fatalf("stableClaudeHash(configA) error = %v", err)
+	}
+	hashB, err := stableClaudeHash(configB)
+	if err != nil {
+		t.Fatalf("stableClaudeHash(configB) error = %v", err)
+	}
+	if hashA != hashB {
+		t.Fatalf("desktop config hash should ignore non-auth fields: %s != %s", hashA, hashB)
+	}
+}
+
 func TestClearAuthFiles(t *testing.T) {
 	t.Run("removes existing files", func(t *testing.T) {
 		tmpDir := t.TempDir()

--- a/internal/provider/claude/claude.go
+++ b/internal/provider/claude/claude.go
@@ -8,6 +8,7 @@
 //   - ~/.claude.json (legacy OAuth session state)
 //   - ~/.config/claude-code/auth.json (auth credentials; or $CLAUDE_CONFIG_DIR/auth.json)
 //   - ~/.claude/settings.json (user settings)
+//   - ~/Library/Application Support/Claude/config.json (encrypted desktop OAuth cache on macOS)
 //   - Project .claude/* files
 //
 // Context isolation for caam:
@@ -103,6 +104,10 @@ func claudeAuthPathForProfile(prof *profile.Profile) string {
 	return filepath.Join(claudeConfigDirForProfile(prof), "auth.json")
 }
 
+func claudeDesktopConfigPath(homeDir string) string {
+	return filepath.Join(homeDir, "Library", "Application Support", "Claude", "config.json")
+}
+
 // AuthFiles returns the auth file specifications for Claude Code.
 // This is the key method for auth file backup/restore.
 func (p *Provider) AuthFiles() []provider.AuthFileSpec {
@@ -127,6 +132,11 @@ func (p *Provider) AuthFiles() []provider.AuthFileSpec {
 		{
 			Path:        filepath.Join(homeDir, ".claude", "settings.json"),
 			Description: "Claude Code settings (apiKeyHelper / API key mode)",
+			Required:    false,
+		},
+		{
+			Path:        claudeDesktopConfigPath(homeDir),
+			Description: "Claude Desktop encrypted OAuth token cache",
 			Required:    false,
 		},
 	}
@@ -333,6 +343,10 @@ func (p *Provider) Logout(ctx context.Context, prof *profile.Profile) error {
 		}
 	}
 
+	if err := clearClaudeDesktopTokenCache(claudeDesktopConfigPath(prof.HomePath())); err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -357,6 +371,11 @@ func (p *Provider) Status(ctx context.Context, prof *profile.Profile) (*provider
 	// Primary credentials file for newer Claude Code versions.
 	credentialsPath := filepath.Join(prof.HomePath(), ".claude", ".credentials.json")
 	if _, err := os.Stat(credentialsPath); err == nil {
+		status.LoggedIn = true
+	}
+
+	desktopConfigPath := claudeDesktopConfigPath(prof.HomePath())
+	if hasToken, err := claudeDesktopConfigHasToken(desktopConfigPath); err == nil && hasToken {
 		status.LoggedIn = true
 	}
 
@@ -411,6 +430,7 @@ func (p *Provider) ValidateProfile(ctx context.Context, prof *profile.Profile) e
 // - ~/.claude/.credentials.json (primary OAuth credentials)
 // - ~/.claude.json (legacy OAuth session state)
 // - ~/.config/claude-code/auth.json (current auth credentials; or $CLAUDE_CONFIG_DIR/auth.json)
+// - ~/Library/Application Support/Claude/config.json (desktop OAuth token cache)
 func (p *Provider) DetectExistingAuth() (*provider.AuthDetection, error) {
 	detection := &provider.AuthDetection{
 		Provider:  p.ID(),
@@ -442,6 +462,10 @@ func (p *Provider) DetectExistingAuth() (*provider.AuthDetection, error) {
 		{
 			path:        filepath.Join(homeDir, ".claude", "settings.json"),
 			description: "Claude Code settings (apiKeyHelper / API key mode)",
+		},
+		{
+			path:        claudeDesktopConfigPath(homeDir),
+			description: "Claude Desktop encrypted OAuth token cache",
 		},
 	}
 
@@ -508,6 +532,14 @@ func (p *Provider) DetectExistingAuth() (*provider.AuthDetection, error) {
 							authLoc.IsValid = true
 						} else {
 							authLoc.IsValid = true // Accept valid settings JSON
+						}
+					case "config.json":
+						if _, ok := parsed["oauth:tokenCache"]; ok {
+							authLoc.IsValid = true
+						} else if _, ok := parsed["oauth:tokenCacheV2"]; ok {
+							authLoc.IsValid = true
+						} else {
+							authLoc.ValidationError = "missing Claude Desktop OAuth token cache"
 						}
 					default:
 						// auth.json - check for typical auth fields
@@ -596,6 +628,13 @@ func (p *Provider) ImportAuth(ctx context.Context, sourcePath string, prof *prof
 		targetPath := filepath.Join(targetDir, "settings.json")
 		if err := copyFile(sourcePath, targetPath); err != nil {
 			return nil, fmt.Errorf("copy settings.json: %w", err)
+		}
+		copiedFiles = append(copiedFiles, targetPath)
+
+	case "config.json":
+		targetPath := claudeDesktopConfigPath(prof.HomePath())
+		if err := copyFile(sourcePath, targetPath); err != nil {
+			return nil, fmt.Errorf("copy Claude Desktop config.json: %w", err)
 		}
 		copiedFiles = append(copiedFiles, targetPath)
 
@@ -746,13 +785,20 @@ func (p *Provider) validateTokenPassive(ctx context.Context, prof *profile.Profi
 	authJsonPath := claudeAuthPathForProfile(prof)
 	credentialsPath := filepath.Join(prof.HomePath(), ".claude", ".credentials.json")
 	settingsPath := filepath.Join(prof.HomePath(), ".claude", "settings.json")
+	desktopConfigPath := claudeDesktopConfigPath(prof.HomePath())
 
 	claudeJsonExists := fileExists(claudeJsonPath)
 	authJsonExists := fileExists(authJsonPath)
 	credentialsExists := fileExists(credentialsPath)
 	settingsExists := fileExists(settingsPath)
+	desktopConfigHasToken, desktopConfigErr := claudeDesktopConfigHasToken(desktopConfigPath)
+	if desktopConfigErr != nil {
+		result.Valid = false
+		result.Error = desktopConfigErr.Error()
+		return result, nil
+	}
 
-	if !claudeJsonExists && !authJsonExists && !credentialsExists {
+	if !claudeJsonExists && !authJsonExists && !credentialsExists && !desktopConfigHasToken {
 		if provider.AuthMode(prof.AuthMode) == provider.AuthModeAPIKey {
 			hasKey, err := claudeSettingsHasAPIKey(settingsPath)
 			if err != nil && settingsExists {
@@ -772,6 +818,12 @@ func (p *Provider) validateTokenPassive(ctx context.Context, prof *profile.Profi
 		result.Valid = false
 		result.Error = "no auth files found"
 		return result, nil
+	}
+
+	if desktopConfigHasToken {
+		// The encrypted desktop token cache has no inspectable expiry. Its
+		// presence is enough for passive validation, matching Claude Code's
+		// current native startup behavior.
 	}
 
 	// Check .credentials.json if it exists
@@ -945,6 +997,57 @@ func claudeSettingsHasAPIKey(path string) (bool, error) {
 		return true, nil
 	}
 	return false, nil
+}
+
+func claudeDesktopConfigHasToken(path string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("cannot read Claude Desktop config: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return false, fmt.Errorf("invalid Claude Desktop config: %v", err)
+	}
+
+	if _, ok := parsed["oauth:tokenCache"]; ok {
+		return true, nil
+	}
+	if _, ok := parsed["oauth:tokenCacheV2"]; ok {
+		return true, nil
+	}
+	return false, nil
+}
+
+func clearClaudeDesktopTokenCache(path string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("read Claude Desktop config: %w", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return fmt.Errorf("parse Claude Desktop config: %w", err)
+	}
+
+	delete(parsed, "oauth:tokenCache")
+	delete(parsed, "oauth:tokenCacheV2")
+
+	updated, err := json.MarshalIndent(parsed, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal Claude Desktop config: %w", err)
+	}
+	updated = append(updated, '\n')
+	if err := atomicWriteFile(path, updated, 0600); err != nil {
+		return fmt.Errorf("write Claude Desktop config: %w", err)
+	}
+	return nil
 }
 
 type claudeCredentials struct {

--- a/internal/provider/claude/claude_test.go
+++ b/internal/provider/claude/claude_test.go
@@ -87,12 +87,12 @@ func TestSupportedAuthModes(t *testing.T) {
 
 func TestAuthFiles(t *testing.T) {
 	t.Setenv("CLAUDE_CONFIG_DIR", "")
-	t.Run("returns four auth file specs", func(t *testing.T) {
+	t.Run("returns five auth file specs", func(t *testing.T) {
 		p := New()
 		files := p.AuthFiles()
 
-		if len(files) != 4 {
-			t.Fatalf("AuthFiles() returned %d files, want 4", len(files))
+		if len(files) != 5 {
+			t.Fatalf("AuthFiles() returned %d files, want 5", len(files))
 		}
 	})
 
@@ -145,6 +145,19 @@ func TestAuthFiles(t *testing.T) {
 		}
 		if file.Required {
 			t.Error(".claude/settings.json should be optional")
+		}
+	})
+
+	t.Run("fifth file is Claude Desktop config.json and optional", func(t *testing.T) {
+		p := New()
+		files := p.AuthFiles()
+
+		file := files[4]
+		if !strings.HasSuffix(file.Path, filepath.Join("Library", "Application Support", "Claude", "config.json")) {
+			t.Errorf("AuthFiles()[4].Path = %q, should end with Library/Application Support/Claude/config.json", file.Path)
+		}
+		if file.Required {
+			t.Error("Claude Desktop config.json should be optional")
 		}
 	})
 
@@ -576,6 +589,47 @@ func TestLogout(t *testing.T) {
 			t.Errorf("Logout() error = %v, should handle missing files", err)
 		}
 	})
+
+	t.Run("scrubs desktop OAuth cache without deleting config", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		prof := &profile.Profile{
+			Name:     "test",
+			Provider: "claude",
+			BasePath: tmpDir,
+		}
+
+		p := New()
+		p.PrepareProfile(context.Background(), prof)
+
+		configPath := claudeDesktopConfigPath(prof.HomePath())
+		writeJSON(t, configPath, map[string]interface{}{
+			"darkMode":           "light",
+			"oauth:tokenCache":   "encrypted-v1",
+			"oauth:tokenCacheV2": "encrypted-v2",
+		})
+
+		if err := p.Logout(context.Background(), prof); err != nil {
+			t.Fatalf("Logout() error = %v", err)
+		}
+
+		data, err := os.ReadFile(configPath)
+		if err != nil {
+			t.Fatalf("desktop config should be preserved: %v", err)
+		}
+		var got map[string]interface{}
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("desktop config should remain valid JSON: %v", err)
+		}
+		if _, ok := got["oauth:tokenCache"]; ok {
+			t.Error("oauth:tokenCache should be removed")
+		}
+		if _, ok := got["oauth:tokenCacheV2"]; ok {
+			t.Error("oauth:tokenCacheV2 should be removed")
+		}
+		if got["darkMode"] != "light" {
+			t.Errorf("non-auth desktop config should be preserved, got %v", got["darkMode"])
+		}
+	})
 }
 
 // =============================================================================
@@ -634,6 +688,30 @@ func TestStatus(t *testing.T) {
 		}
 		if !status.LoggedIn {
 			t.Error("LoggedIn should be true when .claude.json exists")
+		}
+	})
+
+	t.Run("logged in when desktop OAuth cache exists", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		prof := &profile.Profile{
+			Name:     "test",
+			Provider: "claude",
+			BasePath: tmpDir,
+		}
+
+		p := New()
+		p.PrepareProfile(context.Background(), prof)
+
+		writeJSON(t, claudeDesktopConfigPath(prof.HomePath()), map[string]interface{}{
+			"oauth:tokenCacheV2": "encrypted-v2",
+		})
+
+		status, err := p.Status(context.Background(), prof)
+		if err != nil {
+			t.Fatalf("Status() error = %v", err)
+		}
+		if !status.LoggedIn {
+			t.Error("LoggedIn should be true when desktop OAuth cache exists")
 		}
 	})
 
@@ -955,7 +1033,6 @@ func TestAPIKeyModeLifecycle(t *testing.T) {
 	}
 }
 
-
 // =============================================================================
 // DetectExistingAuth Tests
 // =============================================================================
@@ -1113,6 +1190,29 @@ func TestDetectExistingAuth(t *testing.T) {
 		}
 	})
 
+	t.Run("detects Claude Desktop config token cache", func(t *testing.T) {
+		home, _ := setupEnv(t)
+		p := New()
+
+		path := claudeDesktopConfigPath(home)
+		writeJSON(t, path, map[string]interface{}{
+			"darkMode":           "light",
+			"oauth:tokenCacheV2": "encrypted-v2",
+		})
+
+		detection, err := p.DetectExistingAuth()
+		if err != nil {
+			t.Fatalf("DetectExistingAuth() error = %v", err)
+		}
+
+		if !detection.Found {
+			t.Error("Should have found auth")
+		}
+		if detection.Primary.Path != path {
+			t.Errorf("Primary.Path = %q, want %q", detection.Primary.Path, path)
+		}
+	})
+
 	t.Run("prioritizes most recent file", func(t *testing.T) {
 		home, _ := setupEnv(t)
 		p := New()
@@ -1256,6 +1356,9 @@ func writeJSON(t *testing.T, path string, data interface{}) {
 	t.Helper()
 	b, err := json.Marshal(data)
 	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(path, b, 0600); err != nil {


### PR DESCRIPTION
## Summary

This teaches CAAM about Claude Code's current macOS desktop-backed OAuth token cache:

- includes `~/Library/Application Support/Claude/config.json` in Claude auth discovery/profile storage when it contains `oauth:tokenCache` or `oauth:tokenCacheV2`
- hashes only those encrypted OAuth cache fields for stable active-profile detection, so unrelated desktop settings do not affect matching
- scrubs only the OAuth cache keys during clear/logout instead of deleting the whole desktop config
- updates the Claude auth inventory docs and README with the new tracked location

## Problem reproduced

On macOS with Claude Code `2.1.197`, `caam activate claude michael@rebase.team` updated `~/.claude.json`, and `claude auth status` briefly showed the selected account. Starting a fresh Claude Code session then rewrote `~/.claude.json` back to the previous account (`infra@rebase.team`).

The missing source was Claude's desktop/native config file at:

```text
~/Library/Application Support/Claude/config.json
```

That file stores encrypted `oauth:tokenCache` / `oauth:tokenCacheV2` values. Current Claude Code can refresh `~/.claude.json` from that native cache, so swapping only the existing CAAM-tracked files leaves the old account able to reassert itself after activation.

## Local workaround used before the patch

```sh
claude auth logout
claude auth login --email michael@rebase.team
caam backup claude michael@rebase.team --json
```

That repaired the local machine by rotating Claude's native OAuth cache, then refreshing the CAAM profile backup.

## Validation

Passed:

```sh
/opt/homebrew/bin/go test ./internal/authfile ./internal/provider/claude
git diff --check
```

Also attempted:

```sh
/opt/homebrew/bin/go test ./...
```

The full suite currently fails in unrelated areas on this macOS checkout (`cmd/caam/cmd` project-association tests, `internal/exec` SmartRunner E2E behavior, and `internal/pty` read-deadline tests). The changed packages pass their focused tests.
