### PR TITLE
fix(claude): probe XDG-side credentials for identity and login status (#70)

### DIFF
--- a/internal/profile/profile.go
+++ b/internal/profile/profile.go
@@ -134,8 +134,12 @@ func (p *Profile) LoadIdentity() {
 			filepath.Join(p.CodexHomePath(), "auth.json"),
 		}, identity.ExtractFromCodexAuth)
 	case "claude":
+		// XDG-aware Claude Code builds (which see the XDG_CONFIG_HOME this
+		// profile's env sets) write credentials under xdg_config/claude-code/,
+		// not the legacy ~/.claude/ — probe both, legacy first (issue #70).
 		id = loadIdentityFromPaths([]string{
 			filepath.Join(p.HomePath(), ".claude", ".credentials.json"),
+			filepath.Join(p.XDGConfigPath(), "claude-code", ".credentials.json"),
 		}, identity.ExtractFromClaudeCredentials)
 	case "gemini":
 		candidates := []string{

--- a/internal/provider/claude/claude.go
+++ b/internal/provider/claude/claude.go
@@ -414,6 +414,15 @@ func (p *Provider) Status(ctx context.Context, prof *profile.Profile) (*provider
 		status.LoggedIn = true
 	}
 
+	// XDG-aware Claude Code builds see the XDG_CONFIG_HOME this profile's env
+	// sets and write their credentials under xdg_config/claude-code/ instead of
+	// the legacy ~/.claude/ — a profile logged in via `caam exec` + /login was
+	// reported "Logged in: false" without this probe (issue #70).
+	xdgCredentialsPath := filepath.Join(prof.XDGConfigPath(), "claude-code", ".credentials.json")
+	if _, err := os.Stat(xdgCredentialsPath); err == nil {
+		status.LoggedIn = true
+	}
+
 	// API key mode can be configured via settings.json or env var
 	if !status.LoggedIn && provider.AuthMode(prof.AuthMode) == provider.AuthModeAPIKey {
 		settingsPath := filepath.Join(prof.HomePath(), ".claude", "settings.json")


### PR DESCRIPTION
Fixes #70.

XDG-aware Claude Code builds see the `XDG_CONFIG_HOME` an isolated profile's env sets and write credentials under `xdg_config/claude-code/.credentials.json` instead of the legacy `home/.claude/` path. `LoadIdentity` (internal/profile) and the claude provider's `Status()` probed only the legacy location, so a profile logged in via `caam exec` + in-app `/login` reported `Logged in: false` (and carried no identity) while the seat worked fine — anything keyed on that boolean (verify, pool rotation, precheck, TUI) treats the profile as logged out.

This adds the XDG candidate to both probes, legacy path first — mirroring the XDG pass-through the exec side already got in #69.

Tested: `go build ./...` + `go test ./internal/provider/claude/... ./internal/profile/...` green (go 1.25 container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)