### PR TITLE
fix(status): report a rate-limit cap as rate-limited, not token-expired

### DIFF
--- a/cmd/caam/cmd/robot.go
+++ b/cmd/caam/cmd/robot.go
@@ -511,24 +511,8 @@ func buildProfileInfo(tool, profileName, activeProfile string, db *caamdb.DB, co
 }
 
 func getHealthReason(ph *health.ProfileHealth, status health.HealthStatus) string {
-	// Use thresholds from health.DefaultHealthConfig()
-	cfg := health.DefaultHealthConfig()
-
-	if status == health.StatusCritical {
-		if !ph.TokenExpiresAt.IsZero() && time.Until(ph.TokenExpiresAt) <= 0 {
-			return "token expired"
-		}
-		if ph.ErrorCount1h >= cfg.ErrorCountCritical {
-			return fmt.Sprintf("high error rate (%d errors in 1h)", ph.ErrorCount1h)
-		}
-	}
-	if status == health.StatusWarning {
-		if !ph.TokenExpiresAt.IsZero() && time.Until(ph.TokenExpiresAt) < 24*time.Hour {
-			return "token expiring soon"
-		}
-		if ph.ErrorCount1h >= cfg.ErrorCountWarning {
-			return fmt.Sprintf("elevated error rate (%d errors in 1h)", ph.ErrorCount1h)
-		}
+	if reason := health.PrimaryReason(status, ph); reason != "" {
+		return reason
 	}
 	return ""
 }

--- a/cmd/caam/cmd/root.go
+++ b/cmd/caam/cmd/root.go
@@ -301,23 +301,53 @@ func buildProfileHealth(tool, profileName string) *health.ProfileHealth {
 		expInfo, err = health.ParseGeminiExpiry(vaultPath)
 	}
 
-	// If file parsing succeeds and provides an expiry, treat it as authoritative
-	if err == nil && expInfo != nil && !expInfo.ExpiresAt.IsZero() {
-		ph.TokenExpiresAt = expInfo.ExpiresAt
+	// Live credential wins over the vault snapshot. Vault copies freeze at
+	// backup/activate time; Claude refreshes the live file in place. Status
+	// used to treat a days-stale snapshot expiry as "Token expired" while
+	// the live token was hours from expiry (agent-factory-21fp).
+	liveExp := parseLiveProfileExpiry(tool, profileName)
+	if liveExp == nil || liveExp.ExpiresAt.IsZero() {
+		liveExp = parseToolLiveExpiry(tool)
 	}
-
-	// Fallback: when the vault snapshot yields no usable expiry, derive health
-	// from the profile's own live credential instead of leaving TokenExpiresAt
-	// zero (which caps the verdict at 🟡 Warning forever, even for a perfectly
-	// healthy live token — issue #60). Adopted profiles symlink their auth dir
-	// to the live location, so this reads the real, current token.
-	if ph.TokenExpiresAt.IsZero() {
-		if liveExp := parseLiveProfileExpiry(tool, profileName); liveExp != nil && !liveExp.ExpiresAt.IsZero() {
-			ph.TokenExpiresAt = liveExp.ExpiresAt
-		}
+	if liveExp != nil && !liveExp.ExpiresAt.IsZero() {
+		ph.TokenExpiresAt = liveExp.ExpiresAt
+		ph.HasRefreshToken = liveExp.HasRefreshToken
+		ph.ExpiryLive = true
+	} else if err == nil && expInfo != nil && !expInfo.ExpiresAt.IsZero() {
+		ph.TokenExpiresAt = expInfo.ExpiresAt
+		ph.HasRefreshToken = expInfo.HasRefreshToken
+		ph.ExpiryLive = false
 	}
 
 	return ph
+}
+
+// parseToolLiveExpiry reads expiry from the process-live auth location
+// (the files `caam status` already confirmed exist), not from a vault copy.
+func parseToolLiveExpiry(tool string) *health.ExpiryInfo {
+	switch tool {
+	case "claude":
+		info, err := health.ParseClaudeExpiry("")
+		if err != nil {
+			return nil
+		}
+		return info
+	case "codex":
+		home, _ := os.UserHomeDir()
+		info, err := health.ParseCodexExpiry(filepath.Join(home, ".codex", "auth.json"))
+		if err != nil {
+			return nil
+		}
+		return info
+	case "gemini":
+		info, err := health.ParseGeminiExpiry("")
+		if err != nil {
+			return nil
+		}
+		return info
+	default:
+		return nil
+	}
 }
 
 // parseLiveProfileExpiry reads the token expiry from a profile's own auth
@@ -354,7 +384,26 @@ func getProfileHealthWithIdentity(tool, profileName string) (*health.ProfileHeal
 	ph := buildProfileHealth(tool, profileName)
 	id := getVaultIdentity(tool, profileName)
 	applyIdentityToHealth(tool, profileName, ph, id)
+	attachActiveCooldown(tool, profileName, ph)
 	return ph, id
+}
+
+func attachActiveCooldown(tool, profileName string, ph *health.ProfileHealth) {
+	if ph == nil {
+		return
+	}
+	db, err := getDB()
+	if err != nil || db == nil {
+		return
+	}
+	now := time.Now()
+	cooldown, err := db.ActiveCooldown(tool, profileName, now)
+	if err != nil || cooldown == nil {
+		return
+	}
+	if cooldown.CooldownUntil.After(now) {
+		ph.CooldownUntil = cooldown.CooldownUntil
+	}
 }
 
 func getVaultIdentity(tool, profileName string) *identity.Identity {
@@ -915,6 +964,9 @@ func runStatus(cmd *cobra.Command, args []string) error {
 			}
 			if !ph.TokenExpiresAt.IsZero() {
 				st.Health.ExpiresAt = ph.TokenExpiresAt.Format(time.RFC3339)
+			}
+			if reason := health.PrimaryReason(status, ph); reason != "" {
+				st.Health.Reason = reason
 			}
 			// Get cooldown info
 			cooldownStr := getCooldownString(tool, activeProfile, health.FormatOptions{NoColor: true})

--- a/cmd/caam/cmd/status_rate_limit_test.go
+++ b/cmd/caam/cmd/status_rate_limit_test.go
@@ -1,0 +1,209 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/authfile"
+	caamdb "github.com/Dicklesworthstone/coding_agent_account_manager/internal/db"
+)
+
+func claudeOAuthCreds(expiresAtMilli int64, subscription string) string {
+	return fmt.Sprintf(
+		`{"claudeAiOauth":{"accessToken":"access-tok","refreshToken":"refresh-tok","expiresAt":%d,"subscriptionType":%q,"rateLimitTier":"default_claude_max_5x","scopes":["user:inference"]}}`,
+		expiresAtMilli, subscription,
+	)
+}
+
+// TestStatus_RateLimitCapIsNotTokenExpired drives the REAL `caam status --json`
+// path (runStatus), not a helper. The 2026-08-30 incident: a utilization cap
+// was reported as "Token expired" from a stale vault snapshot, with a
+// machine-wide re-login recommendation, while the live credential was valid
+// and error_count was 0.
+func TestStatus_RateLimitCapIsNotTokenExpired(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("CAAM_HOME", filepath.Join(tmpDir, "caam_home"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmpDir, "xdg-data"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpDir, "xdg-config"))
+
+	oldVault := vault
+	oldDB := globalDB
+	globalDB = nil
+	t.Cleanup(func() {
+		vault = oldVault
+		if globalDB != nil {
+			globalDB.Close()
+		}
+		globalDB = oldDB
+	})
+	vault = authfile.NewVault(authfile.DefaultVaultPath())
+
+	claudeDir := filepath.Join(tmpDir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0700); err != nil {
+		t.Fatalf("mkdir claude: %v", err)
+	}
+	credPath := filepath.Join(claudeDir, ".credentials.json")
+
+	// Vault snapshot: expired five days ago, plan "pro" — the frozen fields
+	// caam status was serving.
+	staleExpiry := time.Now().Add(-5 * 24 * time.Hour).UnixMilli()
+	if err := os.WriteFile(credPath, []byte(claudeOAuthCreds(staleExpiry, "pro")), 0600); err != nil {
+		t.Fatalf("write stale creds: %v", err)
+	}
+	fileSet := tools["claude"]()
+	if err := vault.Backup(fileSet, "pm-account"); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+
+	// Live credential refreshes in place: same tokens (profile still matches),
+	// expiry two hours in the future, subscription max.
+	liveExpiry := time.Now().Add(2 * time.Hour).UnixMilli()
+	if err := os.WriteFile(credPath, []byte(claudeOAuthCreds(liveExpiry, "max")), 0600); err != nil {
+		t.Fatalf("write live creds: %v", err)
+	}
+	active, err := vault.ActiveProfile(fileSet)
+	if err != nil || active != "pm-account" {
+		t.Fatalf("ActiveProfile = %q, %v; want pm-account (rotation-stable hash)", active, err)
+	}
+
+	db, err := caamdb.Open()
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	defer db.Close()
+	if _, err := db.SetCooldown("claude", "pm-account", time.Now(), 16*time.Minute, "utilization cap"); err != nil {
+		t.Fatalf("SetCooldown: %v", err)
+	}
+
+	r, w, _ := os.Pipe()
+	oldStdout := os.Stdout
+	os.Stdout = w
+	statusCmd.SetOut(w)
+	if err := statusCmd.Flags().Set("json", "true"); err != nil {
+		t.Fatalf("set json flag: %v", err)
+	}
+	t.Cleanup(func() { _ = statusCmd.Flags().Set("json", "false") })
+
+	runErr := runStatus(statusCmd, []string{"claude"})
+	w.Close()
+	os.Stdout = oldStdout
+	if runErr != nil {
+		t.Fatalf("runStatus error: %v", runErr)
+	}
+	rawOut, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read status output: %v", err)
+	}
+
+	var out statusOutput
+	if err := json.Unmarshal(rawOut, &out); err != nil {
+		t.Fatalf("unmarshal status json %q: %v", string(rawOut), err)
+	}
+	if len(out.Tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d (%s)", len(out.Tools), string(rawOut))
+	}
+	st := out.Tools[0]
+	if st.Health == nil {
+		t.Fatalf("missing health in %s", string(rawOut))
+	}
+	if st.Health.Status == "critical" {
+		t.Errorf("status=%q; a rate-limit cap must not be critical/token-expired; output=%s", st.Health.Status, string(rawOut))
+	}
+	reason := strings.ToLower(st.Health.Reason)
+	if !strings.Contains(reason, "rate limited") {
+		t.Errorf("health.reason=%q, want rate limited; output=%s", st.Health.Reason, string(rawOut))
+	}
+	if strings.Contains(reason, "token expired") {
+		t.Errorf("health.reason=%q still says token expired; output=%s", st.Health.Reason, string(rawOut))
+	}
+	joined := strings.Join(out.Recommendations, "\n")
+	if strings.Contains(strings.ToLower(joined), "caam login") {
+		t.Errorf("recommendations %q must not recommend machine-wide re-login for a cap", joined)
+	}
+	if !strings.Contains(strings.ToLower(joined), "rate limited") {
+		t.Errorf("recommendations %q, want rate limited; output=%s", joined, string(rawOut))
+	}
+}
+
+func TestStatus_LiveTokenOverridesStaleVaultExpiry(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+	t.Setenv("CAAM_HOME", filepath.Join(tmpDir, "caam_home"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(tmpDir, "xdg-data"))
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmpDir, "xdg-config"))
+
+	oldVault := vault
+	oldDB := globalDB
+	globalDB = nil
+	t.Cleanup(func() {
+		vault = oldVault
+		if globalDB != nil {
+			globalDB.Close()
+		}
+		globalDB = oldDB
+	})
+	vault = authfile.NewVault(authfile.DefaultVaultPath())
+
+	claudeDir := filepath.Join(tmpDir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0700); err != nil {
+		t.Fatalf("mkdir claude: %v", err)
+	}
+	credPath := filepath.Join(claudeDir, ".credentials.json")
+	staleExpiry := time.Now().Add(-5 * 24 * time.Hour).UnixMilli()
+	if err := os.WriteFile(credPath, []byte(claudeOAuthCreds(staleExpiry, "pro")), 0600); err != nil {
+		t.Fatalf("write stale creds: %v", err)
+	}
+	fileSet := tools["claude"]()
+	if err := vault.Backup(fileSet, "main"); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+	liveExpiry := time.Now().Add(2 * time.Hour).UnixMilli()
+	if err := os.WriteFile(credPath, []byte(claudeOAuthCreds(liveExpiry, "max")), 0600); err != nil {
+		t.Fatalf("write live creds: %v", err)
+	}
+
+	r, w, _ := os.Pipe()
+	oldStdout := os.Stdout
+	os.Stdout = w
+	statusCmd.SetOut(w)
+	if err := statusCmd.Flags().Set("json", "true"); err != nil {
+		t.Fatalf("set json flag: %v", err)
+	}
+	t.Cleanup(func() { _ = statusCmd.Flags().Set("json", "false") })
+
+	runErr := runStatus(statusCmd, []string{"claude"})
+	w.Close()
+	os.Stdout = oldStdout
+	if runErr != nil {
+		t.Fatalf("runStatus error: %v", runErr)
+	}
+	rawOut, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var out statusOutput
+	if err := json.Unmarshal(rawOut, &out); err != nil {
+		t.Fatalf("unmarshal %q: %v", string(rawOut), err)
+	}
+	if len(out.Tools) != 1 || out.Tools[0].Health == nil {
+		t.Fatalf("unexpected output %s", string(rawOut))
+	}
+	st := out.Tools[0]
+	if st.Health.Status == "critical" {
+		t.Errorf("live-valid token reported critical: %s", string(rawOut))
+	}
+	if strings.Contains(strings.ToLower(st.Health.Reason), "token expired") {
+		t.Errorf("live-valid token reported token expired: %s", string(rawOut))
+	}
+	joined := strings.Join(out.Recommendations, "\n")
+	if strings.Contains(strings.ToLower(joined), "caam login") {
+		t.Errorf("live-valid token recommended login: %q", joined)
+	}
+}

--- a/internal/health/format.go
+++ b/internal/health/format.go
@@ -99,6 +99,45 @@ func FormatTimeRemaining(expiry time.Time) string {
 	}
 }
 
+// PrimaryReason is the single cause shown on `caam status`. A rate-limit
+// cooldown outranks a stale snapshot expiry so a cap is never reported as
+// "Token expired" (agent-factory-21fp).
+func PrimaryReason(status HealthStatus, h *ProfileHealth) string {
+	if h == nil {
+		return ""
+	}
+	now := time.Now()
+	if !h.CooldownUntil.IsZero() && h.CooldownUntil.After(now) {
+		return fmt.Sprintf("Rate limited (resets in %s)", formatDurationNatural(h.CooldownUntil.Sub(now)))
+	}
+	if !h.TokenExpiresAt.IsZero() {
+		ttl := time.Until(h.TokenExpiresAt)
+		if ttl <= 0 {
+			if !h.ExpiryLive {
+				return "" // stale snapshot — unknown, never "Token expired"
+			}
+			if h.HasRefreshToken && h.ErrorCount1h == 0 {
+				return "" // access token expired, refresh still valid — self-healing
+			}
+			return "Token expired"
+		}
+		if ttl < time.Hour {
+			return fmt.Sprintf("Token expires in %s", formatDurationNatural(ttl))
+		}
+	}
+	if h.ErrorCount1h > 0 {
+		if h.ErrorCount1h == 1 {
+			return "1 recent error"
+		}
+		return fmt.Sprintf("%d recent errors", h.ErrorCount1h)
+	}
+	if h.Penalty >= 1.0 {
+		return "High penalty from errors"
+	}
+	_ = status
+	return ""
+}
+
 // FormatStatusWithReason returns a detailed status string with explanation.
 // Example: "🟡 Warning - Token expires in 12 minutes"
 func FormatStatusWithReason(status HealthStatus, health *ProfileHealth, opts FormatOptions) string {
@@ -106,33 +145,8 @@ func FormatStatusWithReason(status HealthStatus, health *ProfileHealth, opts For
 	statusStr := status.String()
 
 	var reasons []string
-
-	if health != nil {
-		// Check token expiry
-		if !health.TokenExpiresAt.IsZero() {
-			ttl := time.Until(health.TokenExpiresAt)
-			if ttl <= 0 {
-				reasons = append(reasons, "Token expired")
-			} else if ttl < 15*time.Minute {
-				reasons = append(reasons, fmt.Sprintf("Token expires in %s", formatDurationNatural(ttl)))
-			} else if ttl < time.Hour {
-				reasons = append(reasons, fmt.Sprintf("Token expires in %s", formatDurationNatural(ttl)))
-			}
-		}
-
-		// Check errors
-		if health.ErrorCount1h > 0 {
-			if health.ErrorCount1h == 1 {
-				reasons = append(reasons, "1 recent error")
-			} else {
-				reasons = append(reasons, fmt.Sprintf("%d recent errors", health.ErrorCount1h))
-			}
-		}
-
-		// Check penalty
-		if health.Penalty >= 1.0 {
-			reasons = append(reasons, "High penalty from errors")
-		}
+	if reason := PrimaryReason(status, health); reason != "" {
+		reasons = append(reasons, reason)
 	}
 
 	var result string
@@ -166,12 +180,28 @@ func FormatRecommendation(provider, profile string, health *ProfileHealth) strin
 
 	var recs []string
 
-	// Check token expiry
+	now := time.Now()
+	if !health.CooldownUntil.IsZero() && health.CooldownUntil.After(now) {
+		recs = append(recs, fmt.Sprintf(
+			"Rate limited; wait for reset in %s. Do not re-login — a cap clears on its timer. Note: claude login is machine-wide and would disrupt every live claude pane.",
+			formatDurationNatural(health.CooldownUntil.Sub(now)),
+		))
+		return strings.Join(recs, "\n")
+	}
+
+	// Never recommend a machine-wide re-login from a timestamp alone.
+	// Require an observed auth failure (error_count > 0) and a LIVE expiry
+	// that is actually past, with no refresh token (agent-factory-21fp).
 	if !health.TokenExpiresAt.IsZero() {
 		ttl := time.Until(health.TokenExpiresAt)
 		if ttl <= 0 {
-			recs = append(recs, fmt.Sprintf("Run \"caam login %s %s\" to re-authenticate", provider, profile))
-		} else if ttl < time.Hour {
+			if health.ExpiryLive && health.ErrorCount1h > 0 && !health.HasRefreshToken {
+				recs = append(recs, fmt.Sprintf(
+					"Run \"caam login %s %s\" to re-authenticate. Note: claude login is machine-wide and would disrupt every live claude pane on this box.",
+					provider, profile,
+				))
+			}
+		} else if ttl < time.Hour && health.ExpiryLive {
 			recs = append(recs, fmt.Sprintf("Run \"caam refresh %s %s\" to refresh expiring token", provider, profile))
 		}
 	}

--- a/internal/health/format_test.go
+++ b/internal/health/format_test.go
@@ -133,10 +133,32 @@ func TestFormatStatusWithReason(t *testing.T) {
 			contains: []string{"🟡", "Token expires"},
 		},
 		{
-			name:     "Expired",
-			status:   StatusCritical,
-			health:   &ProfileHealth{TokenExpiresAt: now.Add(-time.Hour)},
+			name:   "Expired live token",
+			status: StatusCritical,
+			health: &ProfileHealth{
+				TokenExpiresAt: now.Add(-time.Hour),
+				ExpiryLive:     true,
+			},
 			contains: []string{"🔴", "Token expired"},
+		},
+		{
+			name:   "Rate limited outranks stale expiry",
+			status: StatusWarning,
+			health: &ProfileHealth{
+				TokenExpiresAt: now.Add(-5 * 24 * time.Hour),
+				ExpiryLive:     false,
+				CooldownUntil:  now.Add(16 * time.Minute),
+			},
+			contains: []string{"🟡", "Rate limited"},
+		},
+		{
+			name:   "Stale snapshot expiry is not Token expired",
+			status: StatusUnknown,
+			health: &ProfileHealth{
+				TokenExpiresAt: now.Add(-5 * 24 * time.Hour),
+				ExpiryLive:     false,
+			},
+			contains: []string{"⚪", "Unknown"},
 		},
 		{
 			name:     "With errors",
@@ -183,17 +205,31 @@ func TestFormatRecommendation(t *testing.T) {
 			empty:    true,
 		},
 		{
-			name:     "Expired token",
+			name:     "Expired timestamp alone does not recommend login",
 			provider: "claude",
 			profile:  "test",
 			health:   &ProfileHealth{TokenExpiresAt: now.Add(-time.Hour)},
+			empty:    true,
+		},
+		{
+			name:     "Confirmed live expiry with errors recommends login",
+			provider: "claude",
+			profile:  "test",
+			health:   &ProfileHealth{TokenExpiresAt: now.Add(-time.Hour), ExpiryLive: true, ErrorCount1h: 1},
 			contains: "login",
 		},
 		{
-			name:     "Expiring token",
+			name:     "Rate limited recommends wait, not login",
+			provider: "claude",
+			profile:  "main",
+			health:   &ProfileHealth{TokenExpiresAt: now.Add(-5 * 24 * time.Hour), CooldownUntil: now.Add(16 * time.Minute)},
+			contains: "Rate limited",
+		},
+		{
+			name:     "Expiring live token",
 			provider: "codex",
 			profile:  "work",
-			health:   &ProfileHealth{TokenExpiresAt: now.Add(30 * time.Minute)},
+			health:   &ProfileHealth{TokenExpiresAt: now.Add(30 * time.Minute), ExpiryLive: true},
 			contains: "refresh",
 		},
 		{
@@ -222,6 +258,9 @@ func TestFormatRecommendation(t *testing.T) {
 			} else {
 				if !strings.Contains(got, tt.contains) {
 					t.Errorf("FormatRecommendation() = %q, want to contain %q", got, tt.contains)
+				}
+				if strings.Contains(tt.contains, "Rate limited") && strings.Contains(got, "caam login") {
+					t.Errorf("FormatRecommendation() = %q, must not recommend login for a rate-limit cap", got)
 				}
 			}
 		})

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -79,11 +79,21 @@ func CalculateHealth(h *ProfileHealth, config HealthConfig) (HealthStatus, float
 	score := 0.0
 	now := time.Now()
 
-	// Factor 1: Token expiry (primary)
-	if h.TokenExpiresAt.IsZero() {
-		// Unknown expiry - neutral
-	} else if h.TokenExpiresAt.Before(now) {
-		score -= 1.0 // Expired
+	// An active rate-limit cooldown is the real constraint. It must score as
+	// a warning (the cap is real) and must not be outranked by a stale
+	// snapshot expiry that would otherwise go critical (agent-factory-21fp).
+	rateLimited := !h.CooldownUntil.IsZero() && h.CooldownUntil.After(now)
+	staleSnapshotExpiry := !h.TokenExpiresAt.IsZero() && h.TokenExpiresAt.Before(now) && !h.ExpiryLive
+	refreshableAccessExpiry := !h.TokenExpiresAt.IsZero() && h.TokenExpiresAt.Before(now) && h.ExpiryLive && h.HasRefreshToken && h.ErrorCount1h == 0
+	confirmedExpiry := !h.TokenExpiresAt.IsZero() && h.TokenExpiresAt.Before(now) && h.ExpiryLive && !refreshableAccessExpiry
+
+	// Factor 1: Token expiry (primary) — only the LIVE credential counts.
+	if h.TokenExpiresAt.IsZero() || staleSnapshotExpiry {
+		// Unknown / stale snapshot: neutral.
+	} else if refreshableAccessExpiry {
+		score += 1.0 // access token expired, refresh still valid — self-healing, silent
+	} else if confirmedExpiry {
+		score -= 1.0 // Expired live access token without a usable refresh
 	} else {
 		ttl := h.TokenExpiresAt.Sub(now)
 		switch {
@@ -125,23 +135,29 @@ func CalculateHealth(h *ProfileHealth, config HealthConfig) (HealthStatus, float
 		status = StatusWarning
 	}
 
-	// Override if token is strictly expired or critical errors met
-	if !h.TokenExpiresAt.IsZero() {
-		if h.TokenExpiresAt.Before(now) {
+	// Override if the LIVE token is strictly expired, or critical errors met.
+	// A stale snapshot expiry with error_count 0 reports unknown, never
+	// critical — that was the 2026-08-30 misroute (agent-factory-21fp).
+	if staleSnapshotExpiry && h.ErrorCount1h == 0 && !rateLimited {
+		status = StatusUnknown
+	} else if confirmedExpiry {
+		status = StatusCritical
+	} else if !h.TokenExpiresAt.IsZero() && h.TokenExpiresAt.After(now) {
+		ttl := h.TokenExpiresAt.Sub(now)
+		criticalTTL := time.Duration(config.TokenExpiryCriticalMinutes) * time.Minute
+		warningTTL := time.Duration(config.TokenExpiryWarningMinutes) * time.Minute
+		if criticalTTL > 0 && ttl <= criticalTTL {
 			status = StatusCritical
-		} else {
-			ttl := h.TokenExpiresAt.Sub(now)
-			criticalTTL := time.Duration(config.TokenExpiryCriticalMinutes) * time.Minute
-			warningTTL := time.Duration(config.TokenExpiryWarningMinutes) * time.Minute
-			if criticalTTL > 0 && ttl <= criticalTTL {
-				status = StatusCritical
-			} else if warningTTL > 0 && ttl <= warningTTL {
-				// If within warning window (e.g. < 1h), ensure at least Warning
-				if status == StatusHealthy {
-					status = StatusWarning
-				}
+		} else if warningTTL > 0 && ttl <= warningTTL {
+			// If within warning window (e.g. < 1h), ensure at least Warning
+			if status == StatusHealthy {
+				status = StatusWarning
 			}
 		}
+	}
+
+	if rateLimited && status == StatusHealthy {
+		status = StatusWarning
 	}
 
 	if h.ErrorCount1h >= config.ErrorCountCritical {

--- a/internal/health/status_test.go
+++ b/internal/health/status_test.go
@@ -29,12 +29,42 @@ func TestCalculateHealth(t *testing.T) {
 			expectedStatus: StatusHealthy,
 		},
 		{
-			name: "Expired token",
+			name: "Expired live token without refresh is critical",
 			health: &ProfileHealth{
 				TokenExpiresAt: now.Add(-1 * time.Minute),
 				ErrorCount1h:   0,
+				ExpiryLive:     true,
 			},
 			expectedStatus: StatusCritical,
+		},
+		{
+			name: "Stale snapshot expiry with no errors is unknown, never critical",
+			health: &ProfileHealth{
+				TokenExpiresAt: now.Add(-5 * 24 * time.Hour),
+				ErrorCount1h:   0,
+				ExpiryLive:     false,
+			},
+			expectedStatus: StatusUnknown,
+		},
+		{
+			name: "Expired live access token with refresh and no errors is not critical",
+			health: &ProfileHealth{
+				TokenExpiresAt:  now.Add(-1 * time.Minute),
+				ErrorCount1h:    0,
+				ExpiryLive:      true,
+				HasRefreshToken: true,
+			},
+			expectedStatus: StatusHealthy,
+		},
+		{
+			name: "Rate-limited cooldown outranks stale snapshot expiry",
+			health: &ProfileHealth{
+				TokenExpiresAt: now.Add(-5 * 24 * time.Hour),
+				ErrorCount1h:   0,
+				ExpiryLive:     false,
+				CooldownUntil:  now.Add(16 * time.Minute),
+			},
+			expectedStatus: StatusWarning,
 		},
 		{
 			name: "Expiring soon (warning)",

--- a/internal/health/storage.go
+++ b/internal/health/storage.go
@@ -39,6 +39,21 @@ type ProfileHealth struct {
 
 	// LastChecked is when health was last verified.
 	LastChecked time.Time `json:"last_checked,omitempty"`
+
+	// HasRefreshToken is true when the live credential still has a refresh
+	// token. An expired access token with a valid refresh token is normal
+	// self-healing, not a human-login event (agent-factory-21fp).
+	HasRefreshToken bool `json:"-"`
+
+	// ExpiryLive is true when TokenExpiresAt was read from the live credential
+	// on this call, not from a vault/health.json snapshot. A stale snapshot
+	// must never be reported as "Token expired" / critical (agent-factory-21fp).
+	ExpiryLive bool `json:"-"`
+
+	// CooldownUntil is an active rate-limit cooldown, filled by the reporting
+	// path from limit_events. When set, status is "rate limited", not token
+	// expired — even if a stale snapshot expiry is in the past.
+	CooldownUntil time.Time `json:"-"`
 }
 
 // HealthStore holds health data for all profiles.

--- a/internal/health/storage_test.go
+++ b/internal/health/storage_test.go
@@ -206,11 +206,19 @@ func TestCalculateStatus(t *testing.T) {
 			expected: StatusUnknown,
 		},
 		{
-			name: "expired token",
+			name: "expired live token",
+			health: &ProfileHealth{
+				TokenExpiresAt: time.Now().Add(-1 * time.Hour),
+				ExpiryLive:     true,
+			},
+			expected: StatusCritical,
+		},
+		{
+			name: "expired snapshot without live confirmation",
 			health: &ProfileHealth{
 				TokenExpiresAt: time.Now().Add(-1 * time.Hour),
 			},
-			expected: StatusCritical,
+			expected: StatusUnknown,
 		},
 		{
 			name: "expiring soon token",
@@ -487,8 +495,8 @@ func TestStorage_GetStatus(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetStatus failed: %v", err)
 	}
-	if status != StatusCritical {
-		t.Errorf("expected StatusCritical for expired token, got %v", status)
+	if status != StatusUnknown {
+		t.Errorf("expected StatusUnknown for stored snapshot expiry (not live-confirmed), got %v", status)
 	}
 }
 


### PR DESCRIPTION
## Problem

`caam status` reported a utilization cap as **Token expired** and recommended `caam login`, which is machine-wide.

Observed 2026-08-30 on iris:

- Live `~/.claude/.credentials.json` `expiresAt` was hours in the future; `subscriptionType` was `max`.
- caam JSON showed `expires_at` five days stale, `plan_type` `pro`, `health.status` `critical`, `error_count` 0.
- rail-telemetry saw the claude rail at 89% vs the 80% guard. `limit_events` was empty.
- Recommendation: `caam login claude main` — would disrupt every live claude pane to repair a problem that did not exist.

Root: `buildProfileHealth` treated the vault snapshot expiry as authoritative and only read the live credential when the snapshot had **no** expiry. A stale snapshot always won. `FormatRecommendation` emitted a re-login from that timestamp alone.

## Fix

- Prefer live credential expiry over the vault snapshot on every status call.
- Stale snapshot + `error_count == 0` → **unknown**, never critical.
- Live access token expired + refresh token + no errors → silent (self-healing).
- Active `limit_events` cooldown is the **primary** reason: `Rate limited (resets in Xm)`.
- Never recommend `caam login` from a timestamp alone; a cap recommendation says wait, not re-login, and names that claude login is machine-wide.

## Proof

`TestStatus_RateLimitCapIsNotTokenExpired` drives **`runStatus` / `caam status --json`** (the production reporting path), not a helper:

- vault snapshot expired 5 days, live token +2h, cooldown 16m, error_count 0
- JSON: not critical, reason contains `Rate limited`, no `Token expired`, no `caam login` recommendation

Also `TestStatus_LiveTokenOverridesStaleVaultExpiry` (live valid, no cooldown).

agent-factory-21fp
