### PR TITLE
fix(test): run every package under an isolated HOME

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,18 @@ Tests live alongside implementation in `_test.go` files within each package. Tes
 - Edge cases (empty input, max values, boundary conditions)
 - Error conditions
 
+### Test Isolation (MANDATORY)
+
+Every package that has tests carries a `main_test.go` whose `TestMain` calls
+`testutil.RunIsolated(m)`. It points `HOME`, the XDG base directories, and the
+tool-specific home variables at a fresh temporary tree, unsets ambient API
+keys, and puts no-op stand-ins for the agent CLIs and browser openers first on
+`PATH`. Production code exercised by tests (auth restore, `caam add`, wrap)
+resolves `os.UserHomeDir()` and launches real CLIs; without this guard a plain
+`go test ./...` on a machine with live logins overwrote `~/.claude.json` and
+opened OAuth browser windows. `TestEveryTestPackageIsolatesHome` fails the
+suite when a package is missing the guard, so add the file with the package.
+
 ### Running Tests
 
 ```bash

--- a/cmd/caam/cmd/main_test.go
+++ b/cmd/caam/cmd/main_test.go
@@ -1,0 +1,14 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/agent/main_test.go
+++ b/internal/agent/main_test.go
@@ -1,0 +1,14 @@
+package agent
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/api/main_test.go
+++ b/internal/api/main_test.go
@@ -1,0 +1,14 @@
+package api
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/authfile/main_test.go
+++ b/internal/authfile/main_test.go
@@ -1,0 +1,14 @@
+package authfile
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/authpool/main_test.go
+++ b/internal/authpool/main_test.go
@@ -1,0 +1,14 @@
+package authpool
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/authwatch/main_test.go
+++ b/internal/authwatch/main_test.go
@@ -1,0 +1,14 @@
+package authwatch
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/browser/main_test.go
+++ b/internal/browser/main_test.go
@@ -1,0 +1,14 @@
+package browser
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/bundle/main_test.go
+++ b/internal/bundle/main_test.go
@@ -1,0 +1,14 @@
+package bundle
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/codexd/main_test.go
+++ b/internal/codexd/main_test.go
@@ -1,0 +1,14 @@
+package codexd
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/config/main_test.go
+++ b/internal/config/main_test.go
@@ -1,0 +1,14 @@
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/coordinator/main_test.go
+++ b/internal/coordinator/main_test.go
@@ -1,0 +1,14 @@
+package coordinator
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/daemon/main_test.go
+++ b/internal/daemon/main_test.go
@@ -1,0 +1,14 @@
+package daemon
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/db/main_test.go
+++ b/internal/db/main_test.go
@@ -1,0 +1,14 @@
+package db
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/deploy/main_test.go
+++ b/internal/deploy/main_test.go
@@ -1,0 +1,14 @@
+package deploy
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/discovery/main_test.go
+++ b/internal/discovery/main_test.go
@@ -1,0 +1,14 @@
+package discovery
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/e2e/workflows/main_test.go
+++ b/internal/e2e/workflows/main_test.go
@@ -1,0 +1,14 @@
+package workflows
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/exec/main_test.go
+++ b/internal/exec/main_test.go
@@ -1,0 +1,14 @@
+package exec
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/handoff/main_test.go
+++ b/internal/handoff/main_test.go
@@ -1,0 +1,14 @@
+package handoff
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/health/main_test.go
+++ b/internal/health/main_test.go
@@ -1,0 +1,14 @@
+package health
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/identity/main_test.go
+++ b/internal/identity/main_test.go
@@ -1,0 +1,14 @@
+package identity
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/logs/main_test.go
+++ b/internal/logs/main_test.go
@@ -1,0 +1,14 @@
+package logs
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/monitor/main_test.go
+++ b/internal/monitor/main_test.go
@@ -1,0 +1,14 @@
+package monitor
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/notify/main_test.go
+++ b/internal/notify/main_test.go
@@ -1,0 +1,14 @@
+package notify
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/passthrough/main_test.go
+++ b/internal/passthrough/main_test.go
@@ -1,0 +1,14 @@
+package passthrough
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/prediction/main_test.go
+++ b/internal/prediction/main_test.go
@@ -1,0 +1,14 @@
+package prediction
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/pricing/main_test.go
+++ b/internal/pricing/main_test.go
@@ -1,0 +1,14 @@
+package pricing
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/profile/main_test.go
+++ b/internal/profile/main_test.go
@@ -1,0 +1,14 @@
+package profile
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/project/main_test.go
+++ b/internal/project/main_test.go
@@ -1,0 +1,14 @@
+package project
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/provider/agy/main_test.go
+++ b/internal/provider/agy/main_test.go
@@ -1,0 +1,14 @@
+package agy
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/provider/claude/main_test.go
+++ b/internal/provider/claude/main_test.go
@@ -1,0 +1,14 @@
+package claude
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/provider/codex/main_test.go
+++ b/internal/provider/codex/main_test.go
@@ -1,0 +1,14 @@
+package codex
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/provider/gemini/main_test.go
+++ b/internal/provider/gemini/main_test.go
@@ -1,0 +1,14 @@
+package gemini
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/provider/grok/main_test.go
+++ b/internal/provider/grok/main_test.go
@@ -1,0 +1,14 @@
+package grok
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/provider/main_test.go
+++ b/internal/provider/main_test.go
@@ -1,0 +1,14 @@
+package provider
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/pty/main_test.go
+++ b/internal/pty/main_test.go
@@ -1,0 +1,14 @@
+package pty
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/ratelimit/main_test.go
+++ b/internal/ratelimit/main_test.go
@@ -1,0 +1,14 @@
+package ratelimit
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/refresh/main_test.go
+++ b/internal/refresh/main_test.go
@@ -1,0 +1,14 @@
+package refresh
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/rotation/main_test.go
+++ b/internal/rotation/main_test.go
@@ -1,0 +1,14 @@
+package rotation
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/setup/main_test.go
+++ b/internal/setup/main_test.go
@@ -1,0 +1,14 @@
+package setup
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/shallow/main_test.go
+++ b/internal/shallow/main_test.go
@@ -1,0 +1,14 @@
+package shallow
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/signals/main_test.go
+++ b/internal/signals/main_test.go
@@ -1,0 +1,14 @@
+package signals
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/stealth/main_test.go
+++ b/internal/stealth/main_test.go
@@ -1,0 +1,14 @@
+package stealth
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/sync/main_test.go
+++ b/internal/sync/main_test.go
@@ -1,0 +1,14 @@
+package sync
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/tailscale/main_test.go
+++ b/internal/tailscale/main_test.go
@@ -1,0 +1,14 @@
+package tailscale
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/testutil/isolate.go
+++ b/internal/testutil/isolate.go
@@ -1,0 +1,161 @@
+package testutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// ambientEnv lists every variable through which caam, or a CLI it drives,
+// resolves a per-user directory, reaches the desktop, or picks up a credential
+// from the shell. IsolateHome points the directory variables at a fresh
+// temporary tree and unsets the rest, so a test binary cannot reach the
+// developer's real files, real keys, or real display.
+var ambientEnv = []string{
+	"HOME", "USERPROFILE",
+	"XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_CACHE_HOME", "XDG_STATE_HOME",
+	"CAAM_HOME", "CLAUDE_CONFIG_DIR", "CODEX_HOME", "GEMINI_HOME",
+	"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY", "XAI_API_KEY",
+	"BROWSER", "DISPLAY", "WAYLAND_DISPLAY", "XDG_CURRENT_DESKTOP", "XDG_SESSION_TYPE",
+}
+
+// isolatedMarker is set in the environment by IsolateHome so a process
+// re-executed by a test inherits the fact that it is already isolated.
+const isolatedMarker = "CAAM_TEST_ISOLATED"
+
+// stubbedBinaries are the agent CLIs and browser openers that production code
+// launches. Tests get no-op stand-ins for them first on PATH, so a test that
+// reaches a login flow can neither start a real CLI (which rewrites its own
+// config and starts OAuth) nor open a window on the developer's desktop.
+var stubbedBinaries = []string{
+	"claude", "codex", "gemini", "agy", "grok", "opencode", "cursor",
+	"xdg-open", "open", "sensible-browser", "x-www-browser", "gio", "kde-open",
+	"npx",
+}
+
+// RunIsolated runs a package's tests with HOME, and every other variable in
+// ambientEnv, pointed away from the developer's account, and returns the exit
+// code for os.Exit.
+//
+// Tests exercise backup, restore, clear, add, and rotation paths that resolve
+// os.UserHomeDir() inside production code and launch the real agent CLIs. On
+// a machine with live logins that makes a plain `go test ./...` overwrite
+// ~/.claude.json, ~/.claude/.credentials.json, or ~/.codex/auth.json and open
+// OAuth pages in the browser. It has happened: a test run replaced a
+// developer's ~/.claude.json with "{}", logged every running Claude Code
+// session out, and kept opening login tabs. The regex scan in
+// TestNoRealHomeWrites cannot see writers that live in production code, so the
+// guard has to be a runtime one.
+//
+// Every package with tests installs this through TestMain;
+// TestEveryTestPackageIsolatesHome fails the suite when one does not.
+func RunIsolated(m *testing.M) int {
+	// Several e2e tests re-execute the test binary as the CLI under test and
+	// hand it a HOME they built. That child is already inside an isolated
+	// environment; isolating again would replace the paths its parent set.
+	if os.Getenv(isolatedMarker) == "1" {
+		return m.Run()
+	}
+	cleanup, err := IsolateHome()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "testutil: cannot isolate HOME for tests: %v\n", err)
+		return 1
+	}
+	code := m.Run()
+	cleanup()
+	return code
+}
+
+// IsolateHome redirects HOME to a fresh temporary tree, clears the XDG base
+// directories so they derive from it, unsets the tool-specific home, API-key, and display
+// variables, puts no-op stand-ins for the agent CLIs and browser openers first
+// on PATH, and returns a function that restores the previous environment and
+// removes the tree. Individual tests that need a different HOME or PATH still
+// call t.Setenv, which layers on top of this.
+func IsolateHome() (func(), error) {
+	dir, err := os.MkdirTemp("", "caam-testhome-")
+	if err != nil {
+		return nil, err
+	}
+
+	oldHome, _ := os.UserHomeDir()
+	oldCache := os.Getenv("XDG_CACHE_HOME")
+	if oldCache == "" && oldHome != "" {
+		oldCache = filepath.Join(oldHome, ".cache")
+	}
+
+	saved := make(map[string]*string, len(ambientEnv)+3)
+	remember := func(key string) {
+		if value, ok := os.LookupEnv(key); ok {
+			v := value
+			saved[key] = &v
+		} else {
+			saved[key] = nil
+		}
+	}
+	for _, key := range ambientEnv {
+		remember(key)
+		os.Unsetenv(key)
+	}
+	remember("PATH")
+
+	// Keep the Go toolchain's caches where they were: tests that build or run
+	// the caam binary must not re-download modules into the throwaway HOME.
+	for key, value := range map[string]string{
+		"GOPATH":  filepath.Join(oldHome, "go"),
+		"GOCACHE": filepath.Join(oldCache, "go-build"),
+	} {
+		if _, ok := os.LookupEnv(key); !ok && oldHome != "" {
+			remember(key)
+			os.Setenv(key, value)
+		}
+	}
+
+	// The XDG variables stay unset so every base directory derives from the
+	// new HOME, for this process and for any caam binary a test spawns with a
+	// HOME of its own.
+	remember(isolatedMarker)
+	os.Setenv(isolatedMarker, "1")
+	os.Setenv("HOME", dir)
+	os.Setenv("USERPROFILE", dir)
+
+	if runtime.GOOS != "windows" {
+		stubDir := filepath.Join(dir, "stub-bin")
+		if err := writeStubs(stubDir); err != nil {
+			os.RemoveAll(dir)
+			return nil, err
+		}
+		os.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+		// xdg-open falls back to $BROWSER when no desktop is detected.
+		os.Setenv("BROWSER", filepath.Join(stubDir, "xdg-open"))
+	}
+
+	cleanup := func() {
+		for key, value := range saved {
+			if value == nil {
+				os.Unsetenv(key)
+			} else {
+				os.Setenv(key, *value)
+			}
+		}
+		os.RemoveAll(dir)
+	}
+	return cleanup, nil
+}
+
+// writeStubs fills dir with executables that accept any arguments, print
+// nothing, and exit 0.
+func writeStubs(dir string) error {
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	for _, name := range stubbedBinaries {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			return fmt.Errorf("write stub %s: %w", name, err)
+		}
+	}
+	return nil
+}

--- a/internal/testutil/main_test.go
+++ b/internal/testutil/main_test.go
@@ -1,0 +1,11 @@
+package testutil
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain runs this package's tests under an isolated HOME. See RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(RunIsolated(m))
+}

--- a/internal/testutil/safety_check_test.go
+++ b/internal/testutil/safety_check_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"testing"
@@ -297,5 +298,63 @@ func findProjectRoot(t *testing.T) string {
 			t.Fatalf("Could not find project root (go.mod)")
 		}
 		dir = parent
+	}
+}
+
+// TestEveryTestPackageIsolatesHome fails when a package with tests has no
+// TestMain that calls RunIsolated. TestNoRealHomeWrites above scans test
+// sources for dangerous patterns, but the writers that actually corrupted a
+// developer's ~/.claude.json live in production code the tests call
+// (authfile restore, wrap, the CLI commands), which no source scan can see.
+// The runtime guard in RunIsolated is the real protection; this test keeps it
+// from eroding as packages are added.
+func TestEveryTestPackageIsolatesHome(t *testing.T) {
+	rootDir := findProjectRoot(t)
+
+	testFiles := map[string][]string{}
+	err := filepath.Walk(rootDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() && (info.Name() == ".git" || info.Name() == "vendor") {
+			return filepath.SkipDir
+		}
+		if strings.HasSuffix(path, "_test.go") {
+			dir := filepath.Dir(path)
+			testFiles[dir] = append(testFiles[dir], path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Failed to walk directory: %v", err)
+	}
+
+	var missing []string
+	for dir, files := range testFiles {
+		isolated := false
+		for _, file := range files {
+			content, err := os.ReadFile(file)
+			if err != nil {
+				t.Errorf("Failed to read %s: %v", file, err)
+				continue
+			}
+			src := string(content)
+			if strings.Contains(src, "func TestMain(") && strings.Contains(src, "RunIsolated(") {
+				isolated = true
+				break
+			}
+		}
+		if !isolated {
+			relDir, _ := filepath.Rel(rootDir, dir)
+			missing = append(missing, relDir)
+		}
+	}
+
+	if len(missing) > 0 {
+		sort.Strings(missing)
+		t.Errorf("%d package(s) with tests do not run under an isolated HOME:\n\n  %s\n\n"+
+			"FIX: add a main_test.go whose TestMain calls testutil.RunIsolated(m). "+
+			"Without it, `go test` on a machine with live logins can overwrite real auth files.",
+			len(missing), strings.Join(missing, "\n  "))
 	}
 }

--- a/internal/tui/main_test.go
+++ b/internal/tui/main_test.go
@@ -1,0 +1,14 @@
+package tui
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/update/main_test.go
+++ b/internal/update/main_test.go
@@ -1,0 +1,14 @@
+package update
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/usage/main_test.go
+++ b/internal/usage/main_test.go
@@ -1,0 +1,14 @@
+package usage
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/version/main_test.go
+++ b/internal/version/main_test.go
@@ -1,0 +1,14 @@
+package version
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/warnings/main_test.go
+++ b/internal/warnings/main_test.go
@@ -1,0 +1,14 @@
+package warnings
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/watcher/main_test.go
+++ b/internal/watcher/main_test.go
@@ -1,0 +1,14 @@
+package watcher
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/wezterm/main_test.go
+++ b/internal/wezterm/main_test.go
@@ -1,0 +1,14 @@
+package wezterm
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}

--- a/internal/wrap/main_test.go
+++ b/internal/wrap/main_test.go
@@ -1,0 +1,14 @@
+package wrap
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME so nothing they
+// exercise can reach the developer's real auth files. See testutil.RunIsolated.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.RunIsolated(m))
+}


### PR DESCRIPTION
## Incident

Running `go test ./...` on a developer machine with live logins replaced the real `~/.claude.json` with `{}`, logged every running Claude Code session out, and opened OAuth login tabs in the browser. It happened twice in one evening before the cause was pinned down.

## Root cause

Tests exercise production paths that resolve `os.UserHomeDir()` and launch real CLIs. Measured on pristine `main` by running each package against a seeded fake HOME and diffing:

| package | effect on HOME |
|---|---|
| `cmd/caam/cmd` | overwrites `~/.claude.json`; launches the real `claude` binary (which opens the browser) and `npx`; writes `~/.caam/data/caam.db` |
| `internal/wrap` | overwrites `~/.claude.json` |
| `internal/agent` | writes `~/.config/caam/account_usage.json` |
| `internal/daemon` | writes `~/.local/share/caam/{backup_state,auth_pool_state}.json` |
| `internal/tui` | writes `~/.local/share/caam/sync/identity.json` |

The existing guard, `TestNoRealHomeWrites`, scans test sources with regexes. It cannot see writers that live in production code the tests call, which is every case above. On CI this never shows because runners have no logins. `internal/authwatch` and `internal/provider/gemini` also *read* the real HOME and fail on any machine with real state.

## Fix

Runtime isolation, applied uniformly and enforced:

- `internal/testutil/isolate.go`: `RunIsolated(m)` / `IsolateHome()`. Points `HOME`, `USERPROFILE`, and the XDG base directories at a fresh temp tree; unsets `CAAM_HOME`, `CLAUDE_CONFIG_DIR`, `CODEX_HOME`, `GEMINI_HOME`, the provider API keys, `BROWSER`, `DISPLAY`, `WAYLAND_DISPLAY`, and the desktop-detection variables; and puts no-op stand-ins for the agent CLIs and browser openers (`claude`, `codex`, `gemini`, `agy`, `grok`, `opencode`, `cursor`, `xdg-open`, `open`, `sensible-browser`, `gio`, `kde-open`, `npx`) first on `PATH`. Tests that need a specific HOME or PATH still `t.Setenv` on top.
- A `main_test.go` in every package with tests (53) whose `TestMain` calls `testutil.RunIsolated(m)`.
- `TestEveryTestPackageIsolatesHome` in `internal/testutil` fails the suite when a package with tests lacks that `TestMain`, so the guard cannot erode.
- `AGENTS.md`: the rule, stated as mandatory.

## Proof

Full suite run with only `HOME` pointed at a seeded directory (no other environment overrides, exactly what a developer machine looks like): all five sentinel files (`.claude.json`, `.claude/.credentials.json`, `.claude/settings.json`, `.codex/auth.json`, `.gemini/settings.json`) byte-identical afterwards, no new files in that HOME, no browser launched. `internal/authwatch` and `internal/provider/gemini` now pass on a machine with live logins.

Gate: `gofmt -l`, `go vet ./...`, `go build ./cmd/caam`, `go test ./...`.

https://claude.ai/code/session_01UjcKgW7xJGKyA2FH4ypx75
