### PR TITLE
fix(warnings): stop reporting Claude's self-refreshing access token as a fault

### DIFF
--- a/cmd/caam/cmd/rate_limit_reason_test.go
+++ b/cmd/caam/cmd/rate_limit_reason_test.go
@@ -78,3 +78,39 @@ func TestApplyLiveExpiryOverridesStaleSnapshot(t *testing.T) {
 		t.Errorf("StatusReasons() = %q, must not report Token expired for a valid live token", reasons)
 	}
 }
+
+// TestApplyLiveExpiryMarksClaudeSelfRefreshing covers issue #22: a Claude
+// credential carrying a refresh token is renewed in place by Claude Code, so
+// the health snapshot must record that its access-token TTL is not a fault.
+func TestApplyLiveExpiryMarksClaudeSelfRefreshing(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, ".config"))
+
+	claudeDir := filepath.Join(tmp, ".claude")
+	if err := os.MkdirAll(claudeDir, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// An access token in the last minutes of its ~8h life, refreshable.
+	creds := fmt.Sprintf(
+		`{"claudeAiOauth":{"accessToken":"tok","refreshToken":"ref","expiresAt":%d,"subscriptionType":"max"}}`,
+		time.Now().Add(10*time.Minute).UnixMilli(),
+	)
+	if err := os.WriteFile(filepath.Join(claudeDir, ".credentials.json"), []byte(creds), 0o600); err != nil {
+		t.Fatalf("write creds: %v", err)
+	}
+
+	ph := &health.ProfileHealth{}
+	applyLiveExpiry("claude", ph)
+
+	if !ph.SelfRefreshing {
+		t.Fatal("SelfRefreshing = false, want true for a refreshable Claude credential")
+	}
+	if status := health.CalculateStatus(ph); status != health.StatusHealthy {
+		t.Errorf("status = %v, want healthy", status)
+	}
+	if rec := health.FormatRecommendation("claude", "main", ph); rec != "" {
+		t.Errorf("FormatRecommendation() = %q, want empty (caam cannot refresh Claude)", rec)
+	}
+}

--- a/cmd/caam/cmd/root.go
+++ b/cmd/caam/cmd/root.go
@@ -36,6 +36,7 @@ import (
 	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/provider/gemini"
 	grokprovider "github.com/Dicklesworthstone/coding_agent_account_manager/internal/provider/grok"
 	opencodeprovider "github.com/Dicklesworthstone/coding_agent_account_manager/internal/provider/opencode"
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/refresh"
 	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/tui"
 	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/version"
 	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/warnings"
@@ -301,6 +302,13 @@ func buildProfileHealth(tool, profileName string) *health.ProfileHealth {
 		expInfo, err = health.ParseGeminiExpiry(vaultPath)
 	}
 
+	// The credential this profile's health is read from. The vault snapshot is
+	// the fallback; the live file below supersedes it when readable.
+	cred := expInfo
+	if err != nil {
+		cred = nil
+	}
+
 	// Prefer the profile's own live credential over the vault snapshot.
 	// Vault copies are frozen at backup/activate time while tools refresh
 	// the live file in place, so a snapshot expiry can be days stale and
@@ -310,10 +318,17 @@ func buildProfileHealth(tool, profileName string) *health.ProfileHealth {
 	// staying zero, which capped the verdict at 🟡 Warning forever (issue
 	// #60).
 	if liveExp := parseLiveProfileExpiry(tool, profileName); liveExp != nil && !liveExp.ExpiresAt.IsZero() {
-		ph.TokenExpiresAt = liveExp.ExpiresAt
-	} else if err == nil && expInfo != nil && !expInfo.ExpiresAt.IsZero() {
-		// Fallback: the vault snapshot is the best information we have.
-		ph.TokenExpiresAt = expInfo.ExpiresAt
+		cred = liveExp
+	}
+
+	if cred != nil && !cred.ExpiresAt.IsZero() {
+		ph.TokenExpiresAt = cred.ExpiresAt
+	}
+	// Claude Code renews its own access token from the refresh token stored
+	// beside it, and caam's Claude refresh is disabled, so the short TTL is
+	// routine lifecycle rather than a fault to report (issue #22).
+	if cred != nil && cred.HasRefreshToken && refresh.SelfRefreshing(tool) {
+		ph.SelfRefreshing = true
 	}
 
 	return ph
@@ -356,8 +371,15 @@ func applyLiveExpiry(tool string, ph *health.ProfileHealth) {
 	if ph == nil {
 		return
 	}
-	if info := liveAuthExpiry(tool); info != nil && !info.ExpiresAt.IsZero() {
+	info := liveAuthExpiry(tool)
+	if info == nil {
+		return
+	}
+	if !info.ExpiresAt.IsZero() {
 		ph.TokenExpiresAt = info.ExpiresAt
+	}
+	if info.HasRefreshToken && refresh.SelfRefreshing(tool) {
+		ph.SelfRefreshing = true
 	}
 }
 

--- a/internal/health/format.go
+++ b/internal/health/format.go
@@ -35,7 +35,13 @@ func FormatHealthStatus(status HealthStatus, health *ProfileHealth, opts FormatO
 	} else if !health.TokenExpiresAt.IsZero() {
 		ttl := time.Until(health.TokenExpiresAt)
 		if ttl <= 0 {
-			text = "Expired"
+			if health.SelfRefreshing {
+				// Claude Code renews this token on next use, so it is stale,
+				// not expired; "Expired" would read as a dead account.
+				text = "Refreshable"
+			} else {
+				text = "Expired"
+			}
 		} else {
 			text = FormatTimeRemaining(health.TokenExpiresAt)
 		}
@@ -120,8 +126,10 @@ func StatusReasons(h *ProfileHealth) []string {
 		reasons = append(reasons, fmt.Sprintf("Rate limited (resets in %s)", formatDurationNatural(h.RateLimitedUntil.Sub(now))))
 	}
 
-	// Check token expiry
-	if !h.TokenExpiresAt.IsZero() {
+	// Check token expiry. A self-refreshing credential is skipped: its access
+	// token is renewed in place by the provider's CLI, so its TTL is not a
+	// reason for anything (issue #22).
+	if !h.TokenExpiresAt.IsZero() && !h.SelfRefreshing {
 		ttl := h.TokenExpiresAt.Sub(now)
 		if ttl <= 0 {
 			if !rateLimited {
@@ -195,8 +203,10 @@ func FormatRecommendation(provider, profile string, health *ProfileHealth) strin
 		// so never steer a rate-limited profile toward "caam login" (PR #82).
 		recs = append(recs, fmt.Sprintf("%s/%s is rate limited - wait %s for the cap to reset (re-login will not clear it)",
 			provider, profile, formatDurationNatural(health.RateLimitedUntil.Sub(now))))
-	} else if !health.TokenExpiresAt.IsZero() {
-		// Check token expiry
+	} else if !health.TokenExpiresAt.IsZero() && !health.SelfRefreshing {
+		// Check token expiry. Nothing to recommend for a self-refreshing
+		// credential: the provider's CLI renews it on next use, "caam refresh
+		// claude X" is unsupported, and a login is disruptive (issue #22).
 		ttl := health.TokenExpiresAt.Sub(now)
 		if ttl <= 0 {
 			recs = append(recs, fmt.Sprintf("Run \"caam login %s %s\" to re-authenticate", provider, profile))

--- a/internal/health/format_test.go
+++ b/internal/health/format_test.go
@@ -348,3 +348,76 @@ func TestRateLimitCapReporting(t *testing.T) {
 		}
 	})
 }
+
+// TestSelfRefreshingFormatting covers issue #22: nothing in the user-facing
+// output may present the short access-token TTL of a self-refreshing
+// credential as a problem, or recommend a caam refresh/login that cannot help.
+func TestSelfRefreshingFormatting(t *testing.T) {
+	now := time.Now()
+
+	t.Run("StatusReasons omits the access-token TTL", func(t *testing.T) {
+		expiring := &ProfileHealth{
+			TokenExpiresAt: now.Add(20 * time.Minute),
+			SelfRefreshing: true,
+		}
+		if reasons := StatusReasons(expiring); len(reasons) != 0 {
+			t.Errorf("StatusReasons() = %q, want none", reasons)
+		}
+
+		lapsed := &ProfileHealth{
+			TokenExpiresAt: now.Add(-2 * time.Hour),
+			SelfRefreshing: true,
+		}
+		if reasons := StatusReasons(lapsed); len(reasons) != 0 {
+			t.Errorf("StatusReasons() = %q, want none", reasons)
+		}
+	})
+
+	t.Run("FormatRecommendation stays silent", func(t *testing.T) {
+		expiring := &ProfileHealth{
+			TokenExpiresAt: now.Add(20 * time.Minute),
+			SelfRefreshing: true,
+		}
+		if got := FormatRecommendation("claude", "main", expiring); got != "" {
+			t.Errorf("FormatRecommendation() = %q, want empty", got)
+		}
+
+		lapsed := &ProfileHealth{
+			TokenExpiresAt: now.Add(-2 * time.Hour),
+			SelfRefreshing: true,
+		}
+		got := FormatRecommendation("claude", "main", lapsed)
+		if got != "" {
+			t.Errorf("FormatRecommendation() = %q, want empty", got)
+		}
+	})
+
+	t.Run("FormatHealthStatus reports a lapsed token as refreshable", func(t *testing.T) {
+		lapsed := &ProfileHealth{
+			TokenExpiresAt: now.Add(-2 * time.Hour),
+			SelfRefreshing: true,
+		}
+		got := FormatHealthStatus(StatusHealthy, lapsed, FormatOptions{NoColor: true})
+		if strings.Contains(got, "Expired") {
+			t.Errorf("FormatHealthStatus() = %q, must not label a self-refreshing token expired", got)
+		}
+		if !strings.Contains(got, "Refreshable") {
+			t.Errorf("FormatHealthStatus() = %q, want it to contain %q", got, "Refreshable")
+		}
+	})
+
+	t.Run("errors on a self-refreshing profile are still reported", func(t *testing.T) {
+		erroring := &ProfileHealth{
+			TokenExpiresAt: now.Add(20 * time.Minute),
+			SelfRefreshing: true,
+			ErrorCount1h:   4,
+		}
+		reasons := strings.Join(StatusReasons(erroring), ", ")
+		if !strings.Contains(reasons, "4 recent errors") {
+			t.Errorf("StatusReasons() = %q, want it to report the errors", reasons)
+		}
+		if !strings.Contains(FormatRecommendation("claude", "main", erroring), "frequent errors") {
+			t.Error("FormatRecommendation() should still flag frequent errors")
+		}
+	})
+}

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -80,7 +80,11 @@ func CalculateHealth(h *ProfileHealth, config HealthConfig) (HealthStatus, float
 	now := time.Now()
 
 	// Factor 1: Token expiry (primary)
-	if h.TokenExpiresAt.IsZero() {
+	if h.SelfRefreshing {
+		// The provider's own CLI renews this access token in place, so its
+		// TTL says nothing about the account (issue #22).
+		score += 1.0
+	} else if h.TokenExpiresAt.IsZero() {
 		// Unknown expiry - neutral
 	} else if h.TokenExpiresAt.Before(now) {
 		score -= 1.0 // Expired
@@ -125,8 +129,10 @@ func CalculateHealth(h *ProfileHealth, config HealthConfig) (HealthStatus, float
 		status = StatusWarning
 	}
 
-	// Override if token is strictly expired or critical errors met
-	if !h.TokenExpiresAt.IsZero() {
+	// Override if token is strictly expired or critical errors met.
+	// A self-refreshing credential is exempt: its access-token TTL is renewed
+	// by the provider's CLI, not by anything the operator does.
+	if !h.TokenExpiresAt.IsZero() && !h.SelfRefreshing {
 		if h.TokenExpiresAt.Before(now) {
 			if h.RateLimited(now) {
 				// An active rate-limit cooldown outranks the recorded expiry:

--- a/internal/health/status_test.go
+++ b/internal/health/status_test.go
@@ -177,3 +177,68 @@ func TestCalculateHealthRateLimitCap(t *testing.T) {
 		})
 	}
 }
+
+// TestCalculateHealthSelfRefreshing covers issue #22: a credential the
+// provider's own CLI renews in place (Claude Code) must not be downgraded by
+// its short access-token TTL, while every other signal keeps working.
+func TestCalculateHealthSelfRefreshing(t *testing.T) {
+	now := time.Now()
+	config := DefaultHealthConfig()
+
+	tests := []struct {
+		name           string
+		health         *ProfileHealth
+		expectedStatus HealthStatus
+	}{
+		{
+			name: "access token expiring within the warning window stays healthy",
+			health: &ProfileHealth{
+				TokenExpiresAt: now.Add(20 * time.Minute),
+				SelfRefreshing: true,
+			},
+			expectedStatus: StatusHealthy,
+		},
+		{
+			name: "lapsed access token stays healthy",
+			health: &ProfileHealth{
+				TokenExpiresAt: now.Add(-2 * time.Hour),
+				SelfRefreshing: true,
+			},
+			expectedStatus: StatusHealthy,
+		},
+		{
+			name: "same token without self-refresh is critical",
+			health: &ProfileHealth{
+				TokenExpiresAt: now.Add(-2 * time.Hour),
+			},
+			expectedStatus: StatusCritical,
+		},
+		{
+			name: "an active cap still outranks self-refresh",
+			health: &ProfileHealth{
+				TokenExpiresAt:   now.Add(20 * time.Minute),
+				SelfRefreshing:   true,
+				RateLimitedUntil: now.Add(30 * time.Minute),
+			},
+			expectedStatus: StatusWarning,
+		},
+		{
+			name: "errors still escalate a self-refreshing profile",
+			health: &ProfileHealth{
+				TokenExpiresAt: now.Add(20 * time.Minute),
+				SelfRefreshing: true,
+				ErrorCount1h:   5,
+			},
+			expectedStatus: StatusCritical,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status, _ := CalculateHealth(tt.health, config)
+			if status != tt.expectedStatus {
+				t.Errorf("CalculateHealth() status = %v, want %v", status, tt.expectedStatus)
+			}
+		})
+	}
+}

--- a/internal/health/storage.go
+++ b/internal/health/storage.go
@@ -47,6 +47,15 @@ type ProfileHealth struct {
 	// letting a (possibly stale) TokenExpiresAt masquerade as a token-expiry
 	// problem.
 	RateLimitedUntil time.Time `json:"-"`
+
+	// SelfRefreshing marks a credential whose access token is renewed in place
+	// by the provider's own CLI (Claude Code) from a stored refresh token.
+	// caam can neither perform nor needs to perform that refresh, so an
+	// approaching or just-passed access-token expiry is normal lifecycle and
+	// must not downgrade the profile or produce advice the operator cannot act
+	// on (issue #22). Filled in at report time by the caller, which knows the
+	// provider; never persisted.
+	SelfRefreshing bool `json:"-"`
 }
 
 // RateLimited reports whether an active rate-limit cooldown is in effect.

--- a/internal/refresh/claude.go
+++ b/internal/refresh/claude.go
@@ -31,6 +31,18 @@ var (
 	ClaudeRefreshDisabled = true
 )
 
+// SelfRefreshing reports whether the provider's own CLI renews its OAuth
+// access token in place, from the refresh token stored beside it.
+//
+// Claude Code does: it refreshes on next use, and caam's own Claude refresh is
+// disabled (see ClaudeRefreshDisabled and refreshClaude), so "caam refresh
+// claude <profile>" always fails. For such a provider a short access-token TTL
+// is routine lifecycle rather than something the operator can act on, and
+// health and warnings must not report it as a fault (issue #22).
+func SelfRefreshing(provider string) bool {
+	return provider == "claude" && ClaudeRefreshDisabled
+}
+
 // TokenResponse represents the OAuth token response.
 type TokenResponse struct {
 	AccessToken  string `json:"access_token"`

--- a/internal/warnings/warnings.go
+++ b/internal/warnings/warnings.go
@@ -15,6 +15,7 @@ import (
 	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/health"
 	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/profile"
 	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/provider"
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/refresh"
 )
 
 // Warning represents a proactive warning to show the user.
@@ -151,7 +152,24 @@ func (c *Checker) checkVaultProfile(ctx context.Context, tool, profileName strin
 		return warnings
 	}
 
+	// Prefer the profile's own live credential over the vault snapshot. Vault
+	// copies are frozen at backup/activate time while tools refresh the live
+	// file in place, so a snapshot can report an expiry the tool has already
+	// moved past (PR #82).
+	if live := c.liveProfileExpiry(tool, profileName); live != nil && !live.ExpiresAt.IsZero() {
+		expInfo, err = live, nil
+	}
+
 	if err != nil || expInfo == nil || expInfo.ExpiresAt.IsZero() {
+		return warnings
+	}
+
+	// Claude Code renews its own access token in place from the refresh token
+	// stored beside it, and caam's Claude refresh is disabled, so the ~8h
+	// access-token TTL is routine and "caam refresh claude <profile>" cannot
+	// succeed. Warning here fires on every command and recommends an action
+	// that always fails (issue #22).
+	if refresh.SelfRefreshing(tool) && expInfo.HasRefreshToken {
 		return warnings
 	}
 
@@ -188,6 +206,34 @@ func (c *Checker) checkVaultProfile(ctx context.Context, tool, profileName strin
 	}
 
 	return warnings
+}
+
+// liveProfileExpiry reads the token expiry from a profile's own auth directory,
+// which adopted profiles symlink to the location the tool actually refreshes.
+// Best-effort; returns nil on any failure, leaving the vault snapshot in play.
+func (c *Checker) liveProfileExpiry(tool, profileName string) *health.ExpiryInfo {
+	if c.profiles == nil {
+		return nil
+	}
+	prof, err := c.profiles.Load(tool, profileName)
+	if err != nil {
+		return nil
+	}
+	var info *health.ExpiryInfo
+	switch tool {
+	case "claude":
+		info, err = health.ParseClaudeExpiry(filepath.Join(prof.HomePath(), ".claude"))
+	case "codex":
+		info, err = health.ParseCodexExpiry(filepath.Join(prof.CodexHomePath(), "auth.json"))
+	case "gemini":
+		info, err = health.ParseGeminiExpiry(filepath.Join(prof.HomePath(), ".gemini"))
+	default:
+		return nil
+	}
+	if err != nil {
+		return nil
+	}
+	return info
 }
 
 // formatDuration formats a duration in a human-friendly way.

--- a/internal/warnings/warnings_test.go
+++ b/internal/warnings/warnings_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/authfile"
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/profile"
 )
 
 func TestLevelString(t *testing.T) {
@@ -609,5 +610,149 @@ func TestCheckerCustomThresholds(t *testing.T) {
 	}
 	if !foundCritical {
 		t.Error("CheckAll() with custom threshold should return critical warning")
+	}
+}
+
+// writeClaudeCreds writes a Claude credentials file into dir.
+func writeClaudeCreds(t *testing.T, dir string, expiresAt time.Time, refreshToken string) {
+	t.Helper()
+
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatalf("failed to create %s: %v", dir, err)
+	}
+	oauth := map[string]interface{}{
+		"accessToken": "fake-token",
+		"expiresAt":   expiresAt.UnixMilli(),
+	}
+	if refreshToken != "" {
+		oauth["refreshToken"] = refreshToken
+	}
+	credsData, _ := json.Marshal(map[string]interface{}{"claudeAiOauth": oauth})
+	if err := os.WriteFile(filepath.Join(dir, ".credentials.json"), credsData, 0600); err != nil {
+		t.Fatalf("failed to write credentials: %v", err)
+	}
+}
+
+// findWarning returns the warning for tool/profile, or nil.
+func findWarning(warnings []Warning, tool, profileName string) *Warning {
+	for i := range warnings {
+		if warnings[i].Tool == tool && warnings[i].Profile == profileName {
+			return &warnings[i]
+		}
+	}
+	return nil
+}
+
+// TestCheckAllClaudeRefreshableTokenIsSilent covers issue #22: Claude Code
+// renews its own access token from the refresh token stored beside it, and
+// caam's Claude refresh is disabled, so the ~8h access-token TTL must not
+// produce a warning on every command.
+func TestCheckAllClaudeRefreshableTokenIsSilent(t *testing.T) {
+	tmpDir := t.TempDir()
+	vault := authfile.NewVault(tmpDir)
+
+	writeClaudeCreds(t, vault.ProfilePath("claude", "refreshable"), time.Now().Add(30*time.Minute), "refresh-token")
+
+	checker := NewChecker(vault, nil, nil)
+	warns := checker.CheckAll(context.Background())
+
+	if w := findWarning(warns, "claude", "refreshable"); w != nil {
+		t.Errorf("CheckAll() warned about a refreshable Claude token: %+v", *w)
+	}
+}
+
+// TestCheckAllClaudeExpiredRefreshableTokenIsSilent covers the same lifecycle
+// after the access token has lapsed: Claude Code refreshes it on next use, so
+// there is nothing for the operator to do.
+func TestCheckAllClaudeExpiredRefreshableTokenIsSilent(t *testing.T) {
+	tmpDir := t.TempDir()
+	vault := authfile.NewVault(tmpDir)
+
+	writeClaudeCreds(t, vault.ProfilePath("claude", "lapsed"), time.Now().Add(-2*time.Hour), "refresh-token")
+
+	checker := NewChecker(vault, nil, nil)
+	warns := checker.CheckAll(context.Background())
+
+	if w := findWarning(warns, "claude", "lapsed"); w != nil {
+		t.Errorf("CheckAll() warned about an expired but refreshable Claude token: %+v", *w)
+	}
+}
+
+// TestCheckAllClaudeWithoutRefreshTokenStillWarns keeps the existing behavior
+// for a credential that genuinely needs operator action.
+func TestCheckAllClaudeWithoutRefreshTokenStillWarns(t *testing.T) {
+	tmpDir := t.TempDir()
+	vault := authfile.NewVault(tmpDir)
+
+	writeClaudeCreds(t, vault.ProfilePath("claude", "norefresh"), time.Now().Add(-2*time.Hour), "")
+
+	checker := NewChecker(vault, nil, nil)
+	warns := checker.CheckAll(context.Background())
+
+	w := findWarning(warns, "claude", "norefresh")
+	if w == nil {
+		t.Fatal("CheckAll() should warn about an expired Claude token with no refresh token")
+	}
+	if w.Level != LevelCritical || w.Message != "Token EXPIRED" {
+		t.Errorf("warning = %+v, want critical 'Token EXPIRED'", *w)
+	}
+}
+
+// TestCheckAllCodexRefreshableTokenStillWarns pins that the suppression is
+// Claude-specific: caam can refresh Codex, so "caam refresh codex X" remains
+// actionable advice.
+func TestCheckAllCodexRefreshableTokenStillWarns(t *testing.T) {
+	tmpDir := t.TempDir()
+	vault := authfile.NewVault(tmpDir)
+
+	profilePath := vault.ProfilePath("codex", "refreshable")
+	if err := os.MkdirAll(profilePath, 0700); err != nil {
+		t.Fatalf("failed to create profile dir: %v", err)
+	}
+	auth := map[string]interface{}{
+		"access_token":  "fake-token",
+		"refresh_token": "refresh-token",
+		"expires_at":    time.Now().Add(30 * time.Minute).Unix(),
+	}
+	authData, _ := json.Marshal(auth)
+	if err := os.WriteFile(filepath.Join(profilePath, "auth.json"), authData, 0600); err != nil {
+		t.Fatalf("failed to write auth: %v", err)
+	}
+
+	checker := NewChecker(vault, nil, nil)
+	warns := checker.CheckAll(context.Background())
+
+	w := findWarning(warns, "codex", "refreshable")
+	if w == nil {
+		t.Fatal("CheckAll() should still warn about an expiring Codex token")
+	}
+	if w.Action != "caam refresh codex refreshable" {
+		t.Errorf("Action = %q, want %q", w.Action, "caam refresh codex refreshable")
+	}
+}
+
+// TestCheckAllPrefersLiveProfileCredential mirrors PR #82 for warnings: the
+// vault copy is frozen at backup/activate time, so a profile whose own auth
+// directory holds a freshly refreshed token must not be warned about.
+func TestCheckAllPrefersLiveProfileCredential(t *testing.T) {
+	tmpDir := t.TempDir()
+	vault := authfile.NewVault(tmpDir)
+	store := profile.NewStore(filepath.Join(tmpDir, "profiles"))
+
+	// Stale vault snapshot: expired two hours ago, no refresh token.
+	writeClaudeCreds(t, vault.ProfilePath("claude", "live"), time.Now().Add(-2*time.Hour), "")
+
+	prof, err := store.Create("claude", "live", "isolated")
+	if err != nil {
+		t.Fatalf("failed to create profile: %v", err)
+	}
+	// The profile's own credential was refreshed in place and is valid.
+	writeClaudeCreds(t, filepath.Join(prof.HomePath(), ".claude"), time.Now().Add(7*24*time.Hour), "")
+
+	checker := NewChecker(vault, nil, store)
+	warns := checker.CheckAll(context.Background())
+
+	if w := findWarning(warns, "claude", "live"); w != nil {
+		t.Errorf("CheckAll() warned from the stale vault snapshot: %+v", *w)
 	}
 }


### PR DESCRIPTION
## Problem

For the `claude` provider every caam command prints

```
!!! Warning: claude/<profile>: Token expires in N hours
    Run: caam refresh claude <profile>
```

and `caam status` shows a working profile as 🟡 Warning with a "Run caam refresh" recommendation. The warning fires on every invocation (thresholds are 24h/1h and Claude access tokens live ~8h), and the recommended command is unsupported: `internal/refresh` has `ClaudeRefreshDisabled = true` and `refreshClaude` returns `UnsupportedError`. Claude Code renews the access token itself from the refresh token stored beside it.

## Fix

One predicate and one report-time field, so no package guesses about providers:

- `internal/refresh/claude.go`: `SelfRefreshing(provider)`, true for `claude` while `ClaudeRefreshDisabled` holds. The package that owns the fact that caam cannot refresh Claude owns the predicate.
- `internal/health` cannot import `refresh`, so it learns the same fact through `ProfileHealth.SelfRefreshing` (`json:"-"`, never persisted), set by the CLI layer that knows both the provider and whether a refresh token is present (`buildProfileHealth`, `applyLiveExpiry`). It gates `CalculateHealth` (token factor scores healthy, expiry override skipped), `StatusReasons`, `FormatRecommendation`, and `FormatHealthStatus` ("Refreshable" instead of "Expired" for a lapsed self-refreshing token).
- `internal/warnings`: `checkVaultProfile` returns nothing when `refresh.SelfRefreshing(tool) && expInfo.HasRefreshToken`, and now prefers the profile's live credential over the vault snapshot (mirrors PR #82 for adopted profiles).

PR #82's rate-limit logic is intact: an active cooldown still caps a self-refreshing profile at Warning and error counts still escalate it. Claude without a refresh token, Codex, and Gemini behave exactly as before.

Known gap, left for a follow-up: `internal/tui`, `internal/api`, `internal/monitor`, `internal/rotation`, and `precheck` classify from the persisted health store and do not see the report-time field.

## Tests

`warnings_test.go`, `status_test.go`, `format_test.go`, `root_test.go`, `refresh` tests: claude + refresh token → no warning, Healthy, no recommendation; claude without refresh token → unchanged; codex → unchanged; rate-limited self-refreshing profile still Warning. Written red first.

Gate: `gofmt -l`, `go vet ./...`, `go build ./cmd/caam`, `go test ./...` (including `-race` on the touched packages) under an isolated HOME.

Related: #22, #60, #82.

https://claude.ai/code/session_01UjcKgW7xJGKyA2FH4ypx75
