### PR TITLE
fix(health): derive Codex expiry from the access token, not the id_token

### DIFF
--- a/internal/health/expiry.go
+++ b/internal/health/expiry.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/identity"
 )
 
 // ErrNoExpiry indicates that expiry information could not be determined.
@@ -214,13 +216,21 @@ func parseClaudeCredentialsFile(path string) (*ExpiryInfo, error) {
 //
 // Codex stores auth in $CODEX_HOME/auth.json (default ~/.codex/auth.json).
 //
-// Expected JSON structure:
+// API-key mode uses a flat OAuth structure with an explicit expiry:
 //
 //	{
 //	  "access_token": "...",
 //	  "refresh_token": "...",
 //	  "expires_at": 1734451200,  // Unix timestamp (seconds)
 //	  "token_type": "Bearer"
+//	}
+//
+// ChatGPT mode nests JWTs and records no expiry field at all:
+//
+//	{
+//	  "auth_mode": "chatgpt",
+//	  "tokens": {"id_token": "<jwt>", "access_token": "<jwt>", "refresh_token": "rt.1..."},
+//	  "last_refresh": "2026-08-31T09:23:45Z"
 //	}
 func ParseCodexExpiry(authPath string) (*ExpiryInfo, error) {
 	if authPath == "" {
@@ -232,7 +242,7 @@ func ParseCodexExpiry(authPath string) (*ExpiryInfo, error) {
 		authPath = filepath.Join(codexHome, "auth.json")
 	}
 
-	info, err := parseOAuthFile(authPath)
+	data, err := os.ReadFile(authPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, ErrNoAuthFile
@@ -240,8 +250,89 @@ func ParseCodexExpiry(authPath string) (*ExpiryInfo, error) {
 		return nil, err
 	}
 
+	info, err := parseCodexAuth(data)
+	if err != nil {
+		return nil, err
+	}
+
 	info.Source = authPath
 	return info, nil
+}
+
+// codexAuthJSON is the ChatGPT-mode layout written by the Codex CLI, which
+// carries no expiry field: the lifetimes live inside the JWTs themselves.
+type codexAuthJSON struct {
+	IDToken      string `json:"id_token"`
+	AccessToken  string `json:"access_token"`
+	RefreshToken string `json:"refresh_token"`
+
+	Tokens struct {
+		IDToken      string `json:"id_token"`
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+	} `json:"tokens"`
+}
+
+// parseCodexAuth extracts expiry from a Codex auth.json.
+//
+// An explicit expiry field wins when present (API-key mode, and Grok, which
+// reuses this parser). Otherwise the expiry comes from the access_token JWT:
+// Codex authenticates API calls with the access token and refreshes it from
+// refresh_token, while the id_token only supplies identity claims (email,
+// plan, account id) and expires an hour after login. Deriving health from the
+// id_token reports an account that is working right now as expired (#22).
+//
+// The access token's exp is used even when the id_token expires sooner, for
+// the same reason: an expired id_token is the normal steady state of a live
+// Codex session, not a constraint on making requests.
+func parseCodexAuth(data []byte) (*ExpiryInfo, error) {
+	info, err := parseOAuthJSON(data)
+	if err != nil {
+		if !errors.Is(err, ErrNoExpiry) {
+			return nil, err
+		}
+		info = &ExpiryInfo{}
+	}
+
+	var auth codexAuthJSON
+	if err := json.Unmarshal(data, &auth); err != nil {
+		return nil, fmt.Errorf("parse JSON: %w", err)
+	}
+
+	if auth.Tokens.RefreshToken != "" {
+		info.HasRefreshToken = true
+	}
+
+	if info.ExpiresAt.IsZero() {
+		for _, token := range []string{
+			auth.Tokens.AccessToken, auth.AccessToken,
+			auth.Tokens.IDToken, auth.IDToken,
+		} {
+			if exp := jwtExpiry(token); !exp.IsZero() {
+				info.ExpiresAt = exp
+				break
+			}
+		}
+	}
+
+	if info.ExpiresAt.IsZero() && !info.HasRefreshToken {
+		return nil, ErrNoExpiry
+	}
+
+	return info, nil
+}
+
+// jwtExpiry returns the exp claim of an unvalidated JWT, or the zero time when
+// the token is absent, malformed, or carries no exp.
+func jwtExpiry(token string) time.Time {
+	if token == "" {
+		return time.Time{}
+	}
+	id, err := identity.ExtractFromJWT(token)
+	if err != nil {
+		return time.Time{}
+	}
+	return id.ExpiresAt
 }
 
 // ParseGeminiExpiry extracts token expiry from Gemini CLI auth files.
@@ -356,6 +447,11 @@ func parseOAuthFile(path string) (*ExpiryInfo, error) {
 		return nil, err
 	}
 
+	return parseOAuthJSON(data)
+}
+
+// parseOAuthJSON extracts expiry info from OAuth token file contents.
+func parseOAuthJSON(data []byte) (*ExpiryInfo, error) {
 	var oauth oauthJSON
 	if err := json.Unmarshal(data, &oauth); err != nil {
 		return nil, fmt.Errorf("parse JSON: %w", err)

--- a/internal/health/expiry_test.go
+++ b/internal/health/expiry_test.go
@@ -1,6 +1,8 @@
 package health
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -839,4 +841,209 @@ func TestParseExpiryField_AdditionalFormats(t *testing.T) {
 			t.Error("unknown type should return zero time")
 		}
 	})
+}
+
+// TestParseCodexExpiryChatGPTMode covers the auth.json the Codex CLI writes in
+// ChatGPT auth mode: JWTs nested under "tokens" and no explicit expiry field.
+// The id_token is short-lived and carries only identity claims, so the expiry
+// that matters for health is the access_token's.
+func TestParseCodexExpiryChatGPTMode(t *testing.T) {
+	accessExp := time.Now().Add(9 * 24 * time.Hour).Truncate(time.Second)
+	idExp := time.Now().Add(-2 * time.Hour).Truncate(time.Second)
+
+	t.Run("valid access token with expired id token", func(t *testing.T) {
+		path := writeCodexAuth(t, map[string]any{
+			"auth_mode": "chatgpt",
+			"tokens": map[string]any{
+				"id_token":      buildTestJWT(t, map[string]any{"email": "codex@example.com", "exp": idExp.Unix()}),
+				"access_token":  buildTestJWT(t, map[string]any{"exp": accessExp.Unix()}),
+				"refresh_token": "rt.1.example",
+			},
+			"last_refresh": time.Now().Add(-3 * time.Hour).Format(time.RFC3339),
+		})
+
+		info, err := ParseCodexExpiry(path)
+		if err != nil {
+			t.Fatalf("ParseCodexExpiry error: %v", err)
+		}
+		if !info.ExpiresAt.Equal(accessExp) {
+			t.Errorf("ExpiresAt = %v, want access token exp %v", info.ExpiresAt, accessExp)
+		}
+		if !info.HasRefreshToken {
+			t.Error("HasRefreshToken = false, want true for nested tokens.refresh_token")
+		}
+		if info.IsExpired() {
+			t.Error("IsExpired() = true, want false: the access token is still valid")
+		}
+	})
+
+	t.Run("both tokens valid still uses access token", func(t *testing.T) {
+		shortIDExp := time.Now().Add(20 * time.Minute).Truncate(time.Second)
+		path := writeCodexAuth(t, map[string]any{
+			"tokens": map[string]any{
+				"id_token":      buildTestJWT(t, map[string]any{"exp": shortIDExp.Unix()}),
+				"access_token":  buildTestJWT(t, map[string]any{"exp": accessExp.Unix()}),
+				"refresh_token": "rt.1.example",
+			},
+		})
+
+		info, err := ParseCodexExpiry(path)
+		if err != nil {
+			t.Fatalf("ParseCodexExpiry error: %v", err)
+		}
+		if !info.ExpiresAt.Equal(accessExp) {
+			t.Errorf("ExpiresAt = %v, want access token exp %v (not the earlier id_token exp)", info.ExpiresAt, accessExp)
+		}
+	})
+
+	t.Run("id token only", func(t *testing.T) {
+		path := writeCodexAuth(t, map[string]any{
+			"tokens": map[string]any{
+				"id_token": buildTestJWT(t, map[string]any{"exp": accessExp.Unix()}),
+			},
+		})
+
+		info, err := ParseCodexExpiry(path)
+		if err != nil {
+			t.Fatalf("ParseCodexExpiry error: %v", err)
+		}
+		if !info.ExpiresAt.Equal(accessExp) {
+			t.Errorf("ExpiresAt = %v, want id token exp %v", info.ExpiresAt, accessExp)
+		}
+		if info.HasRefreshToken {
+			t.Error("HasRefreshToken = true, want false")
+		}
+	})
+
+	t.Run("no refresh token", func(t *testing.T) {
+		path := writeCodexAuth(t, map[string]any{
+			"tokens": map[string]any{
+				"id_token":     buildTestJWT(t, map[string]any{"exp": idExp.Unix()}),
+				"access_token": buildTestJWT(t, map[string]any{"exp": accessExp.Unix()}),
+			},
+		})
+
+		info, err := ParseCodexExpiry(path)
+		if err != nil {
+			t.Fatalf("ParseCodexExpiry error: %v", err)
+		}
+		if info.HasRefreshToken {
+			t.Error("HasRefreshToken = true, want false")
+		}
+		if !info.ExpiresAt.Equal(accessExp) {
+			t.Errorf("ExpiresAt = %v, want access token exp %v", info.ExpiresAt, accessExp)
+		}
+	})
+
+	t.Run("malformed access token falls back to id token", func(t *testing.T) {
+		path := writeCodexAuth(t, map[string]any{
+			"tokens": map[string]any{
+				"id_token":      buildTestJWT(t, map[string]any{"exp": accessExp.Unix()}),
+				"access_token":  "not-a-jwt",
+				"refresh_token": "rt.1.example",
+			},
+		})
+
+		info, err := ParseCodexExpiry(path)
+		if err != nil {
+			t.Fatalf("ParseCodexExpiry error: %v", err)
+		}
+		if !info.ExpiresAt.Equal(accessExp) {
+			t.Errorf("ExpiresAt = %v, want id token exp %v", info.ExpiresAt, accessExp)
+		}
+	})
+
+	t.Run("malformed tokens with refresh token", func(t *testing.T) {
+		path := writeCodexAuth(t, map[string]any{
+			"tokens": map[string]any{
+				"id_token":      "not-a-jwt",
+				"access_token":  "not-a-jwt-either",
+				"refresh_token": "rt.1.example",
+			},
+		})
+
+		info, err := ParseCodexExpiry(path)
+		if err != nil {
+			t.Fatalf("ParseCodexExpiry error: %v", err)
+		}
+		if !info.ExpiresAt.IsZero() {
+			t.Errorf("ExpiresAt = %v, want zero when no JWT is parseable", info.ExpiresAt)
+		}
+		if !info.HasRefreshToken {
+			t.Error("HasRefreshToken = false, want true")
+		}
+	})
+
+	t.Run("malformed tokens without refresh token", func(t *testing.T) {
+		path := writeCodexAuth(t, map[string]any{
+			"tokens": map[string]any{
+				"id_token": "not-a-jwt",
+			},
+		})
+
+		if _, err := ParseCodexExpiry(path); err != ErrNoExpiry {
+			t.Errorf("error = %v, want ErrNoExpiry", err)
+		}
+	})
+
+	t.Run("invalid json", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "auth.json")
+		if err := os.WriteFile(path, []byte("{not json"), 0600); err != nil {
+			t.Fatalf("write auth.json: %v", err)
+		}
+
+		if _, err := ParseCodexExpiry(path); err == nil {
+			t.Error("expected an error for malformed JSON")
+		}
+	})
+
+	t.Run("explicit expires_at wins over jwt", func(t *testing.T) {
+		explicit := time.Now().Add(48 * time.Hour).Truncate(time.Second)
+		path := writeCodexAuth(t, map[string]any{
+			"access_token":  buildTestJWT(t, map[string]any{"exp": accessExp.Unix()}),
+			"refresh_token": "rt.1.example",
+			"expires_at":    explicit.Unix(),
+		})
+
+		info, err := ParseCodexExpiry(path)
+		if err != nil {
+			t.Fatalf("ParseCodexExpiry error: %v", err)
+		}
+		if !info.ExpiresAt.Equal(explicit) {
+			t.Errorf("ExpiresAt = %v, want explicit expires_at %v", info.ExpiresAt, explicit)
+		}
+	})
+}
+
+// writeCodexAuth writes an auth.json fixture into a temp dir and returns its path.
+func writeCodexAuth(t *testing.T, content map[string]any) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "auth.json")
+	data, err := json.Marshal(content)
+	if err != nil {
+		t.Fatalf("marshal auth.json: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatalf("write auth.json: %v", err)
+	}
+	return path
+}
+
+// buildTestJWT builds an unsigned JWT carrying the given claims.
+func buildTestJWT(t *testing.T, claims map[string]any) string {
+	t.Helper()
+
+	header, err := json.Marshal(map[string]any{"alg": "none", "typ": "JWT"})
+	if err != nil {
+		t.Fatalf("marshal header: %v", err)
+	}
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		t.Fatalf("marshal claims: %v", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(header) + "." +
+		base64.RawURLEncoding.EncodeToString(payload) + ".signature"
 }

--- a/internal/health/status_test.go
+++ b/internal/health/status_test.go
@@ -177,3 +177,29 @@ func TestCalculateHealthRateLimitCap(t *testing.T) {
 		})
 	}
 }
+
+// TestCalculateStatusCodexChatGPTAuth is the end-to-end shape of the bug: a
+// Codex account in active use, whose access token is valid for days but whose
+// id_token expired hours ago, must classify as healthy rather than 🟡 Warning.
+func TestCalculateStatusCodexChatGPTAuth(t *testing.T) {
+	accessExp := time.Now().Add(9 * 24 * time.Hour).Truncate(time.Second)
+	path := writeCodexAuth(t, map[string]any{
+		"auth_mode": "chatgpt",
+		"tokens": map[string]any{
+			"id_token":      buildTestJWT(t, map[string]any{"email": "codex@example.com", "exp": time.Now().Add(-2 * time.Hour).Unix()}),
+			"access_token":  buildTestJWT(t, map[string]any{"exp": accessExp.Unix()}),
+			"refresh_token": "rt.1.example",
+		},
+		"last_refresh": time.Now().Add(-3 * time.Hour).Format(time.RFC3339),
+	})
+
+	info, err := ParseCodexExpiry(path)
+	if err != nil {
+		t.Fatalf("ParseCodexExpiry error: %v", err)
+	}
+
+	ph := &ProfileHealth{TokenExpiresAt: info.ExpiresAt, PlanType: "pro"}
+	if status := CalculateStatus(ph); status != StatusHealthy {
+		t.Errorf("CalculateStatus() = %v, want %v (token expiry %v)", status, StatusHealthy, ph.TokenExpiresAt)
+	}
+}

--- a/internal/identity/codex.go
+++ b/internal/identity/codex.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"time"
 )
 
 // ExtractFromCodexAuth reads a Codex auth.json file and extracts identity from the JWT.
@@ -34,6 +35,14 @@ func ExtractFromCodexAuth(path string) (*Identity, error) {
 			continue
 		}
 		identity.Provider = "codex"
+		// Identity claims (email, plan, account) come from the id_token, but
+		// its lifetime does not describe the account: Codex authenticates API
+		// calls with the access token, and the id_token expires an hour after
+		// login while the session keeps working. Report the access token's
+		// expiry so a healthy account is not shown as expired (#22).
+		if exp, ok := codexAccessTokenExpiry(auth); ok {
+			identity.ExpiresAt = exp
+		}
 		return identity, nil
 	}
 
@@ -48,39 +57,72 @@ type tokenCandidate struct {
 	source string
 }
 
+// codexTokenCandidates lists the tokens to mine for identity claims, id_tokens
+// first: they carry the account's email, plan, and account id.
 func codexTokenCandidates(auth map[string]interface{}) []tokenCandidate {
+	return append(codexIDTokenCandidates(auth), codexAccessTokenCandidates(auth)...)
+}
+
+func codexIDTokenCandidates(auth map[string]interface{}) []tokenCandidate {
 	candidates := []tokenCandidate{
 		{value: stringFromMap(auth, "id_token"), source: "id_token"},
 		{value: stringFromMap(auth, "idToken"), source: "idToken"},
 	}
 
-	rawTokens, ok := auth["tokens"]
-	if ok {
-		if tokenMap, ok := rawTokens.(map[string]interface{}); ok {
-			candidates = append(candidates,
-				tokenCandidate{value: stringFromMap(tokenMap, "id_token"), source: "tokens.id_token"},
-				tokenCandidate{value: stringFromMap(tokenMap, "idToken"), source: "tokens.idToken"},
-			)
-		}
-	}
-
-	candidates = append(candidates,
-		tokenCandidate{value: stringFromMap(auth, "access_token"), source: "access_token"},
-		tokenCandidate{value: stringFromMap(auth, "accessToken"), source: "accessToken"},
-		tokenCandidate{value: stringFromMap(auth, "token"), source: "token"},
-	)
-
-	if ok {
-		if tokenMap, ok := rawTokens.(map[string]interface{}); ok {
-			candidates = append(candidates,
-				tokenCandidate{value: stringFromMap(tokenMap, "access_token"), source: "tokens.access_token"},
-				tokenCandidate{value: stringFromMap(tokenMap, "accessToken"), source: "tokens.accessToken"},
-				tokenCandidate{value: stringFromMap(tokenMap, "token"), source: "tokens.token"},
-			)
-		}
+	if tokenMap := codexNestedTokens(auth); tokenMap != nil {
+		candidates = append(candidates,
+			tokenCandidate{value: stringFromMap(tokenMap, "id_token"), source: "tokens.id_token"},
+			tokenCandidate{value: stringFromMap(tokenMap, "idToken"), source: "tokens.idToken"},
+		)
 	}
 
 	return candidates
+}
+
+func codexAccessTokenCandidates(auth map[string]interface{}) []tokenCandidate {
+	candidates := []tokenCandidate{
+		{value: stringFromMap(auth, "access_token"), source: "access_token"},
+		{value: stringFromMap(auth, "accessToken"), source: "accessToken"},
+		{value: stringFromMap(auth, "token"), source: "token"},
+	}
+
+	if tokenMap := codexNestedTokens(auth); tokenMap != nil {
+		candidates = append(candidates,
+			tokenCandidate{value: stringFromMap(tokenMap, "access_token"), source: "tokens.access_token"},
+			tokenCandidate{value: stringFromMap(tokenMap, "accessToken"), source: "tokens.accessToken"},
+			tokenCandidate{value: stringFromMap(tokenMap, "token"), source: "tokens.token"},
+		)
+	}
+
+	return candidates
+}
+
+func codexNestedTokens(auth map[string]interface{}) map[string]interface{} {
+	rawTokens, ok := auth["tokens"]
+	if !ok {
+		return nil
+	}
+	tokenMap, ok := rawTokens.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	return tokenMap
+}
+
+// codexAccessTokenExpiry returns the exp claim of the first parseable access
+// token, which is the credential the API actually checks.
+func codexAccessTokenExpiry(auth map[string]interface{}) (time.Time, bool) {
+	for _, candidate := range codexAccessTokenCandidates(auth) {
+		if candidate.value == "" {
+			continue
+		}
+		identity, err := ExtractFromJWT(candidate.value)
+		if err != nil || identity.ExpiresAt.IsZero() {
+			continue
+		}
+		return identity.ExpiresAt, true
+	}
+	return time.Time{}, false
 }
 
 func stringFromMap(values map[string]interface{}, key string) string {

--- a/internal/identity/identity_test.go
+++ b/internal/identity/identity_test.go
@@ -347,3 +347,45 @@ func TestFixture_CodexNoTokens(t *testing.T) {
 		t.Error("expected error for fixture without tokens")
 	}
 }
+
+func TestExtractFromCodexAuth_ExpiryFromAccessToken(t *testing.T) {
+	// Codex authenticates API calls with the access token; the id_token only
+	// carries identity claims and expires an hour after login.
+	accessExp := time.Now().Add(9 * 24 * time.Hour).Truncate(time.Second)
+	path := writeAuthFile(t, map[string]interface{}{
+		"tokens": map[string]interface{}{
+			"id_token":      buildJWT(t, map[string]interface{}{"email": "codex@example.com", "exp": time.Now().Add(-2 * time.Hour).Unix()}),
+			"access_token":  buildJWT(t, map[string]interface{}{"exp": accessExp.Unix()}),
+			"refresh_token": "rt.1.example",
+		},
+	})
+
+	identity, err := ExtractFromCodexAuth(path)
+	if err != nil {
+		t.Fatalf("ExtractFromCodexAuth error: %v", err)
+	}
+	if identity.Email != "codex@example.com" {
+		t.Errorf("Email = %q, want %q (identity claims still come from id_token)", identity.Email, "codex@example.com")
+	}
+	if !identity.ExpiresAt.Equal(accessExp) {
+		t.Errorf("ExpiresAt = %v, want access token exp %v", identity.ExpiresAt, accessExp)
+	}
+}
+
+func TestExtractFromCodexAuth_ExpiryFallsBackToIDToken(t *testing.T) {
+	idExp := time.Now().Add(30 * time.Minute).Truncate(time.Second)
+	path := writeAuthFile(t, map[string]interface{}{
+		"tokens": map[string]interface{}{
+			"id_token":     buildJWT(t, map[string]interface{}{"email": "codex@example.com", "exp": idExp.Unix()}),
+			"access_token": "not-a-jwt",
+		},
+	})
+
+	identity, err := ExtractFromCodexAuth(path)
+	if err != nil {
+		t.Fatalf("ExtractFromCodexAuth error: %v", err)
+	}
+	if !identity.ExpiresAt.Equal(idExp) {
+		t.Errorf("ExpiresAt = %v, want id token exp %v", identity.ExpiresAt, idExp)
+	}
+}


### PR DESCRIPTION
## Problem

`caam status` shows a Codex account that is logged in and actively working as 🟡 Warning, and `caam status --json` reports an `identity.expires_at` that is already in the past.

Real `~/.codex/auth.json` (ChatGPT mode) on the reporting machine: `id_token` exp = yesterday, `access_token` exp = 9 days out, `refresh_token` present, Codex CLI running and making requests.

## Root cause

Two independent defects, both from reading the wrong token:

1. `ParseCodexExpiry` delegated to `parseOAuthFile`, whose struct only knows the flat API-key layout with an explicit `expires_at`. The ChatGPT-mode file nests JWTs under `tokens` and has no expiry field, so it returned `ErrNoExpiry`, `TokenExpiresAt` stayed zero, and `CalculateHealth` scored the profile at exactly 0.5, which classifies as Warning. The account could never be Healthy.
2. `ExtractFromCodexAuth` set `ExpiresAt` from the first JWT that parsed, and id_tokens are listed first (correctly, for email/plan claims). Codex authenticates API calls with the access token; the id_token expires an hour after login and stays expired during a working session.

## Fix

- `internal/health/expiry.go`: `ParseCodexExpiry` now parses the ChatGPT layout. Explicit `expires_at` still wins (API-key mode, and Grok which reuses the parser); otherwise the expiry is the access_token's `exp`, falling back to the id_token only when no access token parses. Nested `refresh_token` counts toward `HasRefreshToken`.
- `internal/identity/codex.go`: identity claims still come from the id_token, but `ExpiresAt` is the access token's. Candidate order preserved.

The access token wins even when the id_token expires sooner, on purpose: an expired id_token is the normal steady state of a live session, not a constraint on requests (documented in `parseCodexAuth`).

## Tests

Added in `expiry_test.go`, `status_test.go`, `identity_test.go`: valid access + expired id → healthy with access expiry; both valid → access wins; only id_token → used; malformed JWT; no refresh token. Written red first.

Gate: `gofmt -l`, `go vet ./...`, `go build ./cmd/caam`, `go test ./...` under an isolated HOME.

Related: #22.

https://claude.ai/code/session_01UjcKgW7xJGKyA2FH4ypx75
