### PR TITLE
fix(status): keep the real plan tier instead of collapsing it to "pro"

### DIFF
--- a/cmd/caam/cmd/root.go
+++ b/cmd/caam/cmd/root.go
@@ -524,16 +524,13 @@ func primePlanTypes(tool string, profiles []string) {
 	}
 }
 
+// normalizePlanType canonicalizes the spelling of a provider-reported plan so
+// storage, display, and scoring all agree on one form. It deliberately does not
+// collapse tiers: a Claude Max account reports subscriptionType "max" and must
+// keep reading "max" in `caam status`, `caam ls`, and `--json` output. Scoring
+// ranks the tiers via health.PlanTierOf instead of requiring one spelling.
 func normalizePlanType(planType string) string {
-	plan := strings.ToLower(strings.TrimSpace(planType))
-	switch plan {
-	case "max", "ultra", "plus", "premium":
-		return "pro"
-	case "enterprise", "team", "pro", "free":
-		return plan
-	default:
-		return plan
-	}
+	return strings.ToLower(strings.TrimSpace(planType))
 }
 
 func formatIdentityDisplay(id *identity.Identity) (string, string) {

--- a/cmd/caam/cmd/root_test.go
+++ b/cmd/caam/cmd/root_test.go
@@ -3,12 +3,14 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/authfile"
 	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/health"
 	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/identity"
 	"github.com/spf13/cobra"
@@ -579,6 +581,16 @@ func TestFormatIdentityDisplay_ClaudeEmptyEmail(t *testing.T) {
 			wantPlan:  "claude_pro_2025",
 		},
 		{
+			name: "claude on the max plan",
+			identity: &identity.Identity{
+				Provider: "claude",
+				Email:    "",
+				PlanType: "max",
+			},
+			wantEmail: "n/a",
+			wantPlan:  "Max", // Must not be collapsed to "Pro"
+		},
+		{
 			name: "codex without email",
 			identity: &identity.Identity{
 				Provider: "codex",
@@ -610,5 +622,72 @@ func TestFormatIdentityDisplay_ClaudeEmptyEmail(t *testing.T) {
 				t.Errorf("formatIdentityDisplay() plan = %q, want %q", gotPlan, tc.wantPlan)
 			}
 		})
+	}
+}
+
+// TestNormalizePlanType checks that normalization only canonicalizes spelling.
+// It must never collapse distinct tiers: a Claude Max account that reports
+// subscriptionType "max" has to keep reading "max" in storage, display, and
+// `--json` output.
+func TestNormalizePlanType(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"max", "max"},
+		{"  MAX  ", "max"},
+		{"Ultra", "ultra"},
+		{"plus", "plus"},
+		{"premium", "premium"},
+		{"pro", "pro"},
+		{"Team", "team"},
+		{"ENTERPRISE", "enterprise"},
+		{"free", "free"},
+		{"claude_pro_2025", "claude_pro_2025"},
+		{"   ", ""},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := normalizePlanType(tt.input); got != tt.want {
+				t.Errorf("normalizePlanType(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestGetVaultIdentity_ClaudeMaxReachesJSON covers the value that robot.go
+// serializes as plan_type: a vaulted Max account must surface as "max".
+func TestGetVaultIdentity_ClaudeMaxReachesJSON(t *testing.T) {
+	vaultDir := t.TempDir()
+	prev := vault
+	vault = authfile.NewVault(vaultDir)
+	t.Cleanup(func() { vault = prev })
+
+	profileDir := filepath.Join(vaultDir, "claude", "work")
+	if err := os.MkdirAll(profileDir, 0o700); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	creds := `{"claudeAiOauth":{"accessToken":"t","subscriptionType":"max","rateLimitTier":"default_claude_max_20x","expiresAt":9999999999999}}`
+	if err := os.WriteFile(filepath.Join(profileDir, ".credentials.json"), []byte(creds), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	id := getVaultIdentity("claude", "work")
+	if id == nil {
+		t.Fatal("getVaultIdentity() = nil, want identity")
+	}
+	if id.PlanType != "max" {
+		t.Errorf("PlanType = %q, want %q", id.PlanType, "max")
+	}
+
+	info := RobotProfileInfo{PlanType: id.PlanType}
+	data, err := json.Marshal(info)
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if !strings.Contains(string(data), `"plan_type":"max"`) {
+		t.Errorf("robot JSON = %s, want plan_type \"max\"", data)
 	}
 }

--- a/internal/health/format.go
+++ b/internal/health/format.go
@@ -224,6 +224,14 @@ func FormatPlanType(planType string) string {
 		return "Team"
 	case "free":
 		return "Free"
+	case "max":
+		return "Max"
+	case "ultra":
+		return "Ultra"
+	case "plus":
+		return "Plus"
+	case "premium":
+		return "Premium"
 	default:
 		if planType == "" {
 			return ""

--- a/internal/health/format_test.go
+++ b/internal/health/format_test.go
@@ -239,6 +239,11 @@ func TestFormatPlanType(t *testing.T) {
 		{"Pro", "Pro"},
 		{"team", "Team"},
 		{"free", "Free"},
+		{"max", "Max"},
+		{"MAX", "Max"},
+		{"ultra", "Ultra"},
+		{"plus", "Plus"},
+		{"premium", "Premium"},
 		{"", ""},
 		{"custom", "custom"},
 	}

--- a/internal/health/status.go
+++ b/internal/health/status.go
@@ -1,6 +1,9 @@
 package health
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // HealthStatus represents the overall health state of a profile.
 type HealthStatus int
@@ -41,6 +44,44 @@ func (s HealthStatus) Icon() string {
 		return "🔴"
 	default:
 		return "⚪"
+	}
+}
+
+// PlanTier ranks a subscription plan by the usage headroom it buys. Health
+// scoring and rotation scoring both rank plans, so the ordering lives here once
+// instead of in a switch per package: adding a plan means editing PlanTierOf
+// and nothing else.
+type PlanTier int
+
+const (
+	// PlanTierUnrated covers free plans, blank values, and provider-specific
+	// strings we do not recognize (for example "claude_pro_2025"). These earn
+	// no scoring bonus.
+	PlanTierUnrated PlanTier = iota
+	// PlanTierStandard covers entry paid seats: pro, plus, team.
+	PlanTierStandard
+	// PlanTierHighVolume covers premium individual seats with substantially
+	// larger quotas: Claude Max, Gemini Ultra, and similar.
+	PlanTierHighVolume
+	// PlanTierEnterprise covers negotiated enterprise contracts, which have
+	// the most headroom and are the safest to route work to.
+	PlanTierEnterprise
+)
+
+// PlanTierOf maps a plan string (as stored by normalizePlanType: lowercase and
+// trimmed) to its tier. Unknown values are deliberately unrated rather than
+// guessed at, so a new provider spelling degrades to "no bonus" instead of a
+// wrong one.
+func PlanTierOf(planType string) PlanTier {
+	switch strings.ToLower(strings.TrimSpace(planType)) {
+	case "enterprise":
+		return PlanTierEnterprise
+	case "max", "ultra", "premium":
+		return PlanTierHighVolume
+	case "pro", "plus", "team":
+		return PlanTierStandard
+	default:
+		return PlanTierUnrated
 	}
 }
 
@@ -106,12 +147,17 @@ func CalculateHealth(h *ProfileHealth, config HealthConfig) (HealthStatus, float
 		score -= 0.5
 	}
 
-	// Factor 3: Plan type bonus
-	switch h.PlanType {
-	case "enterprise":
+	// Factor 3: Plan type bonus, ranked by PlanTierOf so this agrees with the
+	// rotation scorer.
+	switch PlanTierOf(h.PlanType) {
+	case PlanTierEnterprise:
 		score += 0.3
-	case "pro", "team":
+	case PlanTierHighVolume:
+		score += 0.25
+	case PlanTierStandard:
 		score += 0.2
+	case PlanTierUnrated:
+		// Free/unknown plans get no bonus.
 	}
 
 	// Factor 4: Penalty (from errors, with decay)

--- a/internal/health/status_test.go
+++ b/internal/health/status_test.go
@@ -177,3 +177,73 @@ func TestCalculateHealthRateLimitCap(t *testing.T) {
 		})
 	}
 }
+
+func TestPlanTierOf(t *testing.T) {
+	tests := []struct {
+		plan string
+		want PlanTier
+	}{
+		{"enterprise", PlanTierEnterprise},
+		{"ENTERPRISE", PlanTierEnterprise},
+		{"max", PlanTierHighVolume},
+		{"Max", PlanTierHighVolume},
+		{"ultra", PlanTierHighVolume},
+		{"premium", PlanTierHighVolume},
+		{"pro", PlanTierStandard},
+		{"plus", PlanTierStandard},
+		{"team", PlanTierStandard},
+		{"free", PlanTierUnrated},
+		{"", PlanTierUnrated},
+		{"claude_pro_2025", PlanTierUnrated},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.plan, func(t *testing.T) {
+			if got := PlanTierOf(tt.plan); got != tt.want {
+				t.Errorf("PlanTierOf(%q) = %v, want %v", tt.plan, got, tt.want)
+			}
+		})
+	}
+
+	if !(PlanTierOf("max") >= PlanTierOf("pro")) {
+		t.Error("max must rank at least as high as pro")
+	}
+	if !(PlanTierOf("enterprise") >= PlanTierOf("max")) {
+		t.Error("enterprise must rank at least as high as max")
+	}
+}
+
+// TestCalculateHealth_PlanBonusKeepsMaxAtLeastAsGoodAsPro guards the fix for
+// Max accounts being stored as "pro": now that the real plan survives, the
+// scoring must not punish a Max account for no longer saying "pro".
+func TestCalculateHealth_PlanBonusKeepsMaxAtLeastAsGoodAsPro(t *testing.T) {
+	config := DefaultHealthConfig()
+	expiry := time.Now().Add(24 * time.Hour)
+
+	scoreFor := func(plan string) float64 {
+		_, score := CalculateHealth(&ProfileHealth{
+			TokenExpiresAt: expiry,
+			PlanType:       plan,
+		}, config)
+		return score
+	}
+
+	free := scoreFor("free")
+	pro := scoreFor("pro")
+	max := scoreFor("max")
+	ultra := scoreFor("ultra")
+	enterprise := scoreFor("enterprise")
+
+	if pro <= free {
+		t.Errorf("pro score %v must beat free score %v", pro, free)
+	}
+	if max < pro {
+		t.Errorf("max score %v must be at least pro score %v", max, pro)
+	}
+	if ultra < pro {
+		t.Errorf("ultra score %v must be at least pro score %v", ultra, pro)
+	}
+	if enterprise < max {
+		t.Errorf("enterprise score %v must be at least max score %v", enterprise, max)
+	}
+}

--- a/internal/health/storage.go
+++ b/internal/health/storage.go
@@ -34,7 +34,9 @@ type ProfileHealth struct {
 	// PenaltyUpdatedAt is when the penalty was last updated.
 	PenaltyUpdatedAt time.Time `json:"penalty_updated_at,omitempty"`
 
-	// PlanType is the subscription tier (free, pro, enterprise).
+	// PlanType is the subscription tier as the provider reports it, lowercased
+	// (free, pro, plus, team, max, ultra, premium, enterprise). Ranked by
+	// PlanTierOf; never collapsed to a single paid spelling.
 	PlanType string `json:"plan_type,omitempty"`
 
 	// LastChecked is when health was last verified.

--- a/internal/rotation/rotation.go
+++ b/internal/rotation/rotation.go
@@ -525,23 +525,10 @@ func (s *Selector) selectSmart(tool string, profiles []string) (*Result, error) 
 				}
 
 				// Plan type bonus
-				switch h.PlanType {
-				case "enterprise":
-					score.Score += 30
+				if bonus := planBonus(h.PlanType); bonus > 0 {
+					score.Score += bonus
 					score.Reasons = append(score.Reasons, Reason{
-						Text:     "Enterprise plan",
-						Positive: true,
-					})
-				case "pro":
-					score.Score += 20
-					score.Reasons = append(score.Reasons, Reason{
-						Text:     "Pro plan",
-						Positive: true,
-					})
-				case "team":
-					score.Score += 20
-					score.Reasons = append(score.Reasons, Reason{
-						Text:     "Team plan",
+						Text:     fmt.Sprintf("%s plan", health.FormatPlanType(h.PlanType)),
 						Positive: true,
 					})
 				}
@@ -651,6 +638,22 @@ func (s *Selector) selectSmart(tool string, profiles []string) (*Result, error) 
 		Algorithm:    AlgorithmSmart,
 		Alternatives: scores,
 	}, nil
+}
+
+// planBonus converts a subscription plan into rotation score points. The
+// ranking itself lives in health.PlanTierOf so that this scorer and the health
+// scorer cannot drift apart; only the point values are local.
+func planBonus(planType string) float64 {
+	switch health.PlanTierOf(planType) {
+	case health.PlanTierEnterprise:
+		return 30
+	case health.PlanTierHighVolume:
+		return 25
+	case health.PlanTierStandard:
+		return 20
+	default:
+		return 0
+	}
 }
 
 // isInCooldown checks if a profile is currently in cooldown.

--- a/internal/rotation/rotation_test.go
+++ b/internal/rotation/rotation_test.go
@@ -2,9 +2,12 @@ package rotation
 
 import (
 	"math/rand"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/health"
 )
 
 func TestNewSelector(t *testing.T) {
@@ -549,5 +552,80 @@ func TestSetAvoidRecent(t *testing.T) {
 	s.SetAvoidRecent(2 * time.Hour)
 	if s.avoidRecent != 2*time.Hour {
 		t.Errorf("avoidRecent = %v, expected 2h", s.avoidRecent)
+	}
+}
+
+// TestPlanBonus_RanksMaxAtLeastAsHighAsPro guards the fix for Claude Max
+// accounts being stored as "pro": the rotation bonus must follow the shared
+// health.PlanTierOf ordering rather than a private list that only knew "pro".
+func TestPlanBonus_RanksMaxAtLeastAsHighAsPro(t *testing.T) {
+	free := planBonus("free")
+	pro := planBonus("pro")
+	team := planBonus("team")
+	max := planBonus("max")
+	ultra := planBonus("ultra")
+	enterprise := planBonus("enterprise")
+
+	if pro <= free {
+		t.Errorf("pro bonus %v must beat free bonus %v", pro, free)
+	}
+	if team != pro {
+		t.Errorf("team bonus %v must match pro bonus %v", team, pro)
+	}
+	if max < pro {
+		t.Errorf("max bonus %v must be at least pro bonus %v", max, pro)
+	}
+	if ultra < pro {
+		t.Errorf("ultra bonus %v must be at least pro bonus %v", ultra, pro)
+	}
+	if enterprise < max {
+		t.Errorf("enterprise bonus %v must be at least max bonus %v", enterprise, max)
+	}
+	if got := planBonus("claude_pro_2025"); got != 0 {
+		t.Errorf("unrecognized plan bonus = %v, want 0", got)
+	}
+}
+
+// TestSelectSmart_ExplainsMaxPlanByName exercises the bonus through the real
+// scoring path: a Max account must be explained as "Max plan", not "Pro plan".
+func TestSelectSmart_ExplainsMaxPlanByName(t *testing.T) {
+	store := health.NewStorage(filepath.Join(t.TempDir(), "health.json"))
+	expiry := time.Now().Add(24 * time.Hour)
+
+	if err := store.UpdateProfile("claude", "maxacct", &health.ProfileHealth{
+		TokenExpiresAt: expiry,
+		PlanType:       "max",
+	}); err != nil {
+		t.Fatalf("UpdateProfile(maxacct) error = %v", err)
+	}
+	if err := store.UpdateProfile("claude", "proacct", &health.ProfileHealth{
+		TokenExpiresAt: expiry,
+		PlanType:       "pro",
+	}); err != nil {
+		t.Fatalf("UpdateProfile(proacct) error = %v", err)
+	}
+
+	s := NewSelector(AlgorithmSmart, store, nil)
+	result, err := s.Select("claude", []string{"maxacct", "proacct"}, "")
+	if err != nil {
+		t.Fatalf("Select() error = %v", err)
+	}
+
+	// Selection between two equally healthy profiles is jittered, so assert on
+	// the scored explanations rather than on which profile came out on top.
+	reasons := map[string]string{}
+	for _, alt := range result.Alternatives {
+		var texts []string
+		for _, r := range alt.Reasons {
+			texts = append(texts, r.Text)
+		}
+		reasons[alt.Name] = strings.Join(texts, "|")
+	}
+
+	if got := reasons["maxacct"]; !strings.Contains(got, "Max plan") {
+		t.Errorf("reasons for maxacct = %q, want one containing %q", got, "Max plan")
+	}
+	if got := reasons["proacct"]; !strings.Contains(got, "Pro plan") {
+		t.Errorf("reasons for proacct = %q, want one containing %q", got, "Pro plan")
 	}
 }


### PR DESCRIPTION
## Problem

Claude Max accounts display as "Pro" in `caam status`, `caam ls`, and `--json` (`plan_type: "pro"`). `.credentials.json` says `subscriptionType: "max"`, `rateLimitTier: "default_claude_max_20x"`.

## Root cause

`normalizePlanType` in `cmd/caam/cmd/root.go` collapsed `max`, `ultra`, `plus`, `premium` into `"pro"` before the value was stored, displayed, or emitted. The collapse existed only so two independent plan-bonus switches (`health.CalculateHealth`, `rotation.selectSmart`) could recognize a paid plan.

## Fix

- `internal/health/status.go`: one exported ranking, `PlanTier` / `PlanTierOf`: Unrated (free, blank, unknown) < Standard (pro, plus, team) < HighVolume (max, ultra, premium) < Enterprise. Both scorers rank through it, so they cannot drift.
- `internal/rotation/rotation.go`: `planBonus` delegates to `PlanTierOf` (30/25/20/0); the reason text becomes `"<Plan> plan"` via `FormatPlanType`, so "Pro plan" / "Team plan" / "Enterprise plan" are unchanged and "Max plan" is new.
- `internal/health/format.go`: `FormatPlanType` learns Max / Ultra / Plus / Premium.
- `normalizePlanType` now only lowercases and trims.

Every `PlanType` / `FormatPlanType` caller was checked (robot JSON, TUI, watch, health store, config); nothing assumed the `"pro"` spelling. `rateLimitTier` is deliberately not surfaced: it would not distinguish the reported case and adds plumbing.

## Tests

`status_test.go`, `rotation_test.go`, `root_test.go`: tier ranking; max scores ≥ pro in both scorers; explanation text through the real `Select` path; `normalizePlanType` keeps "max"; a vaulted `max` credential reaches `plan_type: "max"` in robot JSON. Written red first.

Gate: `gofmt -l`, `go vet ./...`, `go build ./cmd/caam`, `go test ./...` under an isolated HOME.

https://claude.ai/code/session_01UjcKgW7xJGKyA2FH4ypx75
