### PR TITLE
feat(quota): show cached Claude usage per profile without network

### DIFF
--- a/README.md
+++ b/README.md
@@ -426,6 +426,7 @@ sel=$(caam ls claude | fzf --prompt 'claude> ') && [ -n "$sel" ] && caam activat
 |---------|-------------|
 | `caam activate <tool> --auto` | Auto-select the best profile using rotation algorithm |
 | `caam next <tool>` | Switch to the next profile in rotation (use `--dry-run` to preview without switching) |
+| `caam quota [claude]` | Show cached usage per Claude profile, read from disk with no network (`--json` supported) |
 | `caam run <tool> [-- args]` | Wrap CLI execution with automatic failover on rate limits |
 | `caam cooldown set <provider/profile>` | Mark profile as rate-limited (default: 60min cooldown) |
 | `caam cooldown list` | List active cooldowns with remaining time |
@@ -499,6 +500,33 @@ Health scoring combines multiple factors:
 - **Plan type**: Enterprise/Pro plans get slight scoring boosts
 
 The penalty system uses **exponential decay** (20% reduction every 5 minutes) so temporary issues don't permanently mark a profile as unhealthy. After about 30 minutes of no errors, a profile's penalty score returns to near zero.
+
+### Cached Usage: `caam quota`
+
+`caam quota` shows how much of each Claude account's usage windows is spent, **without touching the network**:
+
+```
+PROFILE           EMAIL  PLAN  5H                WEEKLY            FABLE             RESETS           AS OF
+● adriana-gmail   n/a    Pro   █████░░░░░   53%  █░░░░░░░░░   11%  ██░░░░░░░░   19%  Fri Sep 4 08:00  18m ago
+  adriana-syneto  n/a    Pro   ░░░░░░░░░░ ~  0%  ░░░░░░░░░░ ~  4%  ░░░░░░░░░░ ~  3%  Wed Sep 2 20:59  3h ago
+  vadim           n/a    Pro   ░░░░░░░░░░ ~  0%  ███░░░░░░░ ~ 29%  █████░░░░░ ~ 54%  Wed Sep 2 10:00  3h ago
+
+usage as cached by Claude Code; refreshed by that account's own sessions. No network.
+```
+
+Claude Code already caches each account's utilization in that account's own `.claude.json`. `caam quota` reads those files and nothing else. `caam limits`, by contrast, answers the same question by presenting every profile's bearer token from one process — one machine speaking for several accounts at once, which is the shared-credential pattern that gets subscriptions revoked. Reading the cache avoids that entirely.
+
+The trade-off is freshness: a profile's numbers only move when that profile itself runs a session. Every row states its own age, and marks figures taken from a frozen vault snapshot with `~`. The active profile is read from the live `~/.claude.json`, so its numbers are as current as your last turn.
+
+Reading the table:
+
+- `●` marks the active profile; rows tagged `(shallow)` are shallow profiles.
+- **5H** is the rolling 5-hour session window; **WEEKLY** is the all-model weekly cap; the third bar is the weekly cap for the model named in its header.
+- A window whose reset time has already passed reads 0%: it rolled over, and nothing has run against it since.
+- **RESETS** is when the weekly window rolls over; **AS OF** is how stale the snapshot is.
+- `--json` emits the same data per profile, including `source` (`live`, `snapshot`, or `shallow`), `account_uuid`, `fetched_at`, and each window's `percent`, `resets_at`, and `rolled`.
+
+Only Claude caches usage on disk. `caam quota <other-provider>` exits 1 and points you at `caam limits`.
 
 ### Smart Rotation Algorithms
 

--- a/README.md
+++ b/README.md
@@ -506,10 +506,10 @@ The penalty system uses **exponential decay** (20% reduction every 5 minutes) so
 `caam quota` shows how much of each Claude account's usage windows is spent, **without touching the network**:
 
 ```
-PROFILE           EMAIL  PLAN  5H                WEEKLY            FABLE             RESETS           AS OF
-● adriana-gmail   n/a    Pro   █████░░░░░   53%  █░░░░░░░░░   11%  ██░░░░░░░░   19%  Fri Sep 4 08:00  18m ago
-  adriana-syneto  n/a    Pro   ░░░░░░░░░░ ~  0%  ░░░░░░░░░░ ~  4%  ░░░░░░░░░░ ~  3%  Wed Sep 2 20:59  3h ago
-  vadim           n/a    Pro   ░░░░░░░░░░ ~  0%  ███░░░░░░░ ~ 29%  █████░░░░░ ~ 54%  Wed Sep 2 10:00  3h ago
+PROFILE           LANE           EMAIL  PLAN  5H                WEEKLY            FABLE             RESETS           AS OF
+* adriana-gmail   active         n/a    Pro   █████░░░░░   53%  █░░░░░░░░░   11%  ██░░░░░░░░   19%  Fri Sep 4 08:00  18m ago
+  adriana-syneto  vault          n/a    Pro   ░░░░░░░░░░ ~  0%  ░░░░░░░░░░ ~  4%  ░░░░░░░░░░ ~  3%  Wed Sep 2 20:59  3h ago
+  vadim           vault+shallow  n/a    Pro   ░░░░░░░░░░ ~  0%  ███░░░░░░░ ~ 29%  █████░░░░░ ~ 54%  Wed Sep 2 10:00  3h ago
 
 usage as cached by Claude Code; refreshed by that account's own sessions. No network.
 ```
@@ -520,7 +520,7 @@ The trade-off is freshness: a profile's numbers only move when that profile itse
 
 Reading the table:
 
-- `●` marks the active profile; rows tagged `(shallow)` are shallow profiles.
+- One row per **account**. `*` marks the account active in `~/.claude`; **LANE** lists where it is set up: `active`, `vault` (a vault profile not currently active), `shallow` (a shallow profile; `shallow(<name>)` when its name differs). A vault profile and a shallow profile logged into the same account draw down the same windows, so they fold into one row carrying the freshest numbers.
 - **5H** is the rolling 5-hour session window; **WEEKLY** is the all-model weekly cap; the third bar is the weekly cap for the model named in its header.
 - A window whose reset time has already passed reads 0%: it rolled over, and nothing has run against it since.
 - **RESETS** is when the weekly window rolls over; **AS OF** is how stale the snapshot is.

--- a/cmd/caam/cmd/quota.go
+++ b/cmd/caam/cmd/quota.go
@@ -56,11 +56,17 @@ const quotaFooter = "usage as cached by Claude Code; refreshed by that account's
 
 // quotaRow is one profile's cached usage, as rendered and as emitted by --json.
 type quotaRow struct {
-	Profile     string               `json:"profile"`
-	Email       string               `json:"email"`
-	Plan        string               `json:"plan"`
-	Source      string               `json:"source"`
-	Active      bool                 `json:"active"`
+	Profile string `json:"profile"`
+	Email   string `json:"email"`
+	Plan    string `json:"plan"`
+	Source  string `json:"source"`
+	Active  bool   `json:"active"`
+	// Lanes lists where this account is set up: "active" (the vault profile
+	// currently switched into ~/.claude), "vault" (a vault profile that is
+	// not active), and "shallow" or "shallow(<name>)" for a shallow profile
+	// (named when its name differs from Profile). One account can be in
+	// several lanes at once; its usage is one number regardless.
+	Lanes       []string             `json:"lanes"`
 	AccountUUID string               `json:"account_uuid"`
 	FetchedAt   *time.Time           `json:"fetched_at"`
 	Windows     []usage.CachedWindow `json:"windows"`
@@ -171,7 +177,128 @@ func collectQuotaRows(scan quotaScan) ([]quotaRow, error) {
 	}
 
 	rows = append(rows, collectShallowQuotaRows(scan)...)
-	return rows, nil
+	return mergeQuotaRows(rows), nil
+}
+
+// mergeQuotaRows folds the rows that belong to one account into one. Usage is
+// a property of the account, not of the place its cache was read from: a
+// vault profile and a shallow profile logged into the same account draw down
+// the same windows, so listing them twice with two different ages reads as
+// two accounts. The merged row keeps the freshest numbers (latest fetch;
+// ties go live > shallow > snapshot), the vault profile's name when there is
+// one, and every lane the account is set up in. Rows without an account uuid
+// cannot be matched and stay as they are.
+func mergeQuotaRows(rows []quotaRow) []quotaRow {
+	var out []quotaRow
+	index := map[string]int{}
+	for _, row := range rows {
+		row.Lanes = quotaLanes(row, row.Profile)
+		if row.AccountUUID == "" {
+			out = append(out, row)
+			continue
+		}
+		i, seen := index[row.AccountUUID]
+		if !seen {
+			index[row.AccountUUID] = len(out)
+			out = append(out, row)
+			continue
+		}
+		out[i] = mergeQuotaPair(out[i], row)
+	}
+	// Lane names are relative to the row's final name, which is only known
+	// once every row of the account has been folded in.
+	for i := range out {
+		out[i].Lanes = quotaNormalizeLanes(out[i].Lanes, out[i].Profile)
+	}
+	return out
+}
+
+// mergeQuotaPair combines two rows known to be the same account.
+func mergeQuotaPair(a, b quotaRow) quotaRow {
+	base, other := a, b
+	if quotaFresher(b, a) {
+		base, other = b, a
+	}
+	merged := base
+	merged.Active = a.Active || b.Active
+	// The vault profile's name is the one `caam activate`/`next` use, so it
+	// names the row whenever the account has one.
+	if base.Source == quotaSourceShallow && other.Source != quotaSourceShallow {
+		merged.Profile = other.Profile
+	}
+	if merged.Email == "" || merged.Email == "n/a" || merged.Email == "unknown" {
+		if other.Email != "" {
+			merged.Email = other.Email
+		}
+	}
+	merged.Lanes = append(append([]string{}, a.Lanes...), b.Lanes...)
+	return merged
+}
+
+// quotaFresher reports whether a's numbers should be preferred over b's.
+func quotaFresher(a, b quotaRow) bool {
+	switch {
+	case a.FetchedAt == nil:
+		return false
+	case b.FetchedAt == nil:
+		return true
+	case !a.FetchedAt.Equal(*b.FetchedAt):
+		return a.FetchedAt.After(*b.FetchedAt)
+	}
+	return quotaSourceRank(a.Source) > quotaSourceRank(b.Source)
+}
+
+func quotaSourceRank(source string) int {
+	switch source {
+	case quotaSourceLive:
+		return 3
+	case quotaSourceShallow:
+		return 2
+	default:
+		return 1
+	}
+}
+
+// quotaLanes describes one unmerged row's lane.
+func quotaLanes(row quotaRow, _ string) []string {
+	switch {
+	case row.Active:
+		return []string{"active"}
+	case row.Source == quotaSourceShallow:
+		// Always carry the shallow profile's name; quotaNormalizeLanes
+		// collapses it to plain "shallow" once the merged row's name is known.
+		return []string{"shallow(" + row.Profile + ")"}
+	default:
+		return []string{"vault"}
+	}
+}
+
+// quotaNormalizeLanes dedupes lanes, orders them active, vault, shallow, and
+// renames shallow lanes relative to the merged row's profile name.
+func quotaNormalizeLanes(lanes []string, profile string) []string {
+	rank := func(l string) int {
+		switch {
+		case l == "active":
+			return 0
+		case l == "vault":
+			return 1
+		default:
+			return 2
+		}
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, l := range lanes {
+		if l == "shallow("+profile+")" {
+			l = "shallow"
+		}
+		if !seen[l] {
+			seen[l] = true
+			out = append(out, l)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return rank(out[i]) < rank(out[j]) })
+	return out
 }
 
 // collectShallowQuotaRows adds a row per Claude shallow profile. Shallow
@@ -281,25 +408,28 @@ func renderQuotaTable(w io.Writer, rows []quotaRow, now time.Time, color bool) e
 	var table bytes.Buffer
 	tw := tabwriter.NewWriter(&table, 0, 0, 2, ' ', 0)
 
-	fmt.Fprintf(tw, "PROFILE\tEMAIL\tPLAN\t5H\tWEEKLY\t%s\tRESETS\tAS OF\n", strings.ToUpper(quotaScopedTitle(rows)))
+	fmt.Fprintf(tw, "PROFILE\tLANE\tEMAIL\tPLAN\t5H\tWEEKLY\t%s\tRESETS\tAS OF\n", strings.ToUpper(quotaScopedTitle(rows)))
 
 	// bars[i] holds the plain bar cells of the i-th data line, in the order
 	// they appear, so they can be colorized after the layout is fixed.
 	bars := make([][]quotaBarCell, len(rows))
 
 	for i, row := range rows {
+		// The active marker is plain ASCII on purpose: glyphs such as "●" are
+		// ambiguous-width and shift the row in some terminals.
 		name := "  " + row.Profile
 		if row.Active {
-			name = "● " + row.Profile
+			name = "* " + row.Profile
 		}
-		if row.Source == quotaSourceShallow {
-			name += " (shallow)"
+		lanes := strings.Join(row.Lanes, "+")
+		if lanes == "" {
+			lanes = "-"
 		}
 
 		if len(row.Windows) == 0 {
 			// A trailing, un-tab-terminated cell sits outside the aligned
 			// columns, so an account with no snapshot cannot stretch the table.
-			fmt.Fprintf(tw, "%s\t%s\t%s\tno usage cache yet (run a session)\n", name, row.Email, row.Plan)
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\tno usage cache yet (run a session)\n", name, lanes, row.Email, row.Plan)
 			continue
 		}
 
@@ -315,8 +445,8 @@ func renderQuotaTable(w io.Writer, rows []quotaRow, now time.Time, color bool) e
 			}
 		}
 
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			name, row.Email, row.Plan, cells[0].Text, cells[1].Text, cells[2].Text,
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			name, lanes, row.Email, row.Plan, cells[0].Text, cells[1].Text, cells[2].Text,
 			quotaResetsCell(row.Windows), quotaAsOfCell(row, now))
 	}
 

--- a/cmd/caam/cmd/quota.go
+++ b/cmd/caam/cmd/quota.go
@@ -1,0 +1,476 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/spf13/cobra"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/authfile"
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/identity"
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/shallow"
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/usage"
+)
+
+// =============================================================================
+// caam quota — remaining usage per Claude profile, read from local disk.
+// =============================================================================
+//
+// `caam limits` answers the same question over the network, but to do so it
+// presents every profile's bearer token from a single process: one machine
+// speaking for several accounts at once, which is the shared-credential shape
+// that gets subscriptions revoked. Claude Code already caches each account's
+// utilization in that account's own .claude.json, refreshed by that account's
+// own sessions. This command reads those files and nothing else — no token is
+// used, no request is made.
+//
+// The cost of that trade is freshness: a profile's numbers only move when that
+// profile actually runs. The table says so, per row, via its AS OF column and
+// the "~" marker on figures taken from a frozen vault snapshot.
+
+// Where a row's numbers came from.
+const (
+	// quotaSourceLive is the live ~/.claude.json of the active profile.
+	quotaSourceLive = "live"
+	// quotaSourceSnapshot is a vault copy, frozen when the profile was last
+	// switched away from.
+	quotaSourceSnapshot = "snapshot"
+	// quotaSourceShallow is a shallow profile's own HOME.
+	quotaSourceShallow = "shallow"
+)
+
+// quotaBarWidth is the number of cells in a usage bar.
+const quotaBarWidth = 10
+
+// quotaFooter explains what the numbers are and are not.
+const quotaFooter = "usage as cached by Claude Code; refreshed by that account's own sessions. No network."
+
+// quotaRow is one profile's cached usage, as rendered and as emitted by --json.
+type quotaRow struct {
+	Profile     string               `json:"profile"`
+	Email       string               `json:"email"`
+	Plan        string               `json:"plan"`
+	Source      string               `json:"source"`
+	Active      bool                 `json:"active"`
+	AccountUUID string               `json:"account_uuid"`
+	FetchedAt   *time.Time           `json:"fetched_at"`
+	Windows     []usage.CachedWindow `json:"windows"`
+}
+
+// quotaScan describes where to look for cached usage. Every path is injected
+// so the walk can be tested against a temporary vault.
+type quotaScan struct {
+	vault          *authfile.Vault
+	liveClaudeJSON string
+	active         string
+	shallowMgr     *shallow.Manager
+	now            time.Time
+
+	// identityFor resolves the account behind a profile: shallowHome is empty
+	// for vault profiles. A nil func leaves every row's email and plan unknown.
+	identityFor func(profile, shallowHome string) *identity.Identity
+}
+
+var quotaCmd = &cobra.Command{
+	Use:   "quota [provider]",
+	Short: "Show cached Claude usage per profile (no network)",
+	Long: `Show how much of each Claude account's usage window is spent, read from
+the usage snapshot Claude Code caches in each profile's own .claude.json.
+
+Unlike 'caam limits', this command makes no request and presents no token: it
+only reads files already on disk, so no single process ever speaks for several
+accounts at once. The trade-off is freshness — a profile's numbers only change
+when that profile itself runs a session. Each row reports how old its snapshot
+is, and marks figures read from a frozen vault copy with "~".
+
+Rows cover vault profiles (the active one read live, the rest from the vault)
+and shallow profiles. Only Claude caches usage locally.
+
+Examples:
+  caam quota            # table of every Claude profile
+  caam quota claude     # same; claude is the default provider
+  caam quota --json     # machine-readable output`,
+	RunE: runQuota,
+}
+
+func init() {
+	rootCmd.AddCommand(quotaCmd)
+	quotaCmd.Flags().Bool("json", false, "output as JSON")
+}
+
+func runQuota(cmd *cobra.Command, args []string) error {
+	provider := "claude"
+	if len(args) > 0 {
+		provider = strings.ToLower(strings.TrimSpace(args[0]))
+	}
+	if provider != "claude" {
+		cmd.SilenceUsage = true
+		return fmt.Errorf("no local usage cache for %s (only claude caches usage on disk; try: caam limits %s)", provider, provider)
+	}
+
+	asJSON, _ := cmd.Flags().GetBool("json")
+	now := time.Now()
+
+	scan := quotaScan{
+		vault:          vault,
+		liveClaudeJSON: liveClaudeJSONPath(),
+		now:            now,
+		identityFor:    quotaIdentity,
+	}
+	if active, err := vault.ActiveProfile(authfile.ClaudeAuthFiles()); err == nil {
+		scan.active = active
+	}
+	if mgr, err := shallow.NewManager("", ""); err == nil {
+		scan.shallowMgr = mgr
+	}
+
+	rows, err := collectQuotaRows(scan)
+	if err != nil {
+		cmd.SilenceUsage = true
+		return err
+	}
+
+	out := cmd.OutOrStdout()
+	if asJSON {
+		return renderQuotaJSON(out, rows)
+	}
+	return renderQuotaTable(out, rows, now, isTerminal())
+}
+
+// collectQuotaRows reads the cached usage of every Claude profile caam knows
+// about. A profile with no cache yet is still a row, with no windows: the
+// table says so rather than hiding the account.
+func collectQuotaRows(scan quotaScan) ([]quotaRow, error) {
+	var rows []quotaRow
+
+	names, err := scan.vault.List("claude")
+	if err != nil {
+		return nil, fmt.Errorf("read vault: %w", err)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		path := scan.vault.BackupPath("claude", name, ".claude.json")
+		source := quotaSourceSnapshot
+		if name == scan.active && scan.active != "" {
+			// The vault copy froze when this profile was switched to; the live
+			// file is the one Claude Code has been updating since.
+			path = scan.liveClaudeJSON
+			source = quotaSourceLive
+		}
+		rows = append(rows, buildQuotaRow(scan, name, "", path, source, name == scan.active && scan.active != ""))
+	}
+
+	rows = append(rows, collectShallowQuotaRows(scan)...)
+	return rows, nil
+}
+
+// collectShallowQuotaRows adds a row per Claude shallow profile. Shallow
+// profiles are a convenience layer, so any failure to enumerate them is
+// silently skipped rather than failing the whole table.
+func collectShallowQuotaRows(scan quotaScan) []quotaRow {
+	if scan.shallowMgr == nil {
+		return nil
+	}
+	profiles, err := scan.shallowMgr.List()
+	if err != nil {
+		return nil
+	}
+
+	var rows []quotaRow
+	for _, p := range profiles {
+		provider, err := scan.shallowMgr.ResolveProvider(p.Name)
+		if err != nil || provider != "claude" {
+			continue
+		}
+		path := filepath.Join(p.Path, ".claude.json")
+		rows = append(rows, buildQuotaRow(scan, p.Name, p.Path, path, quotaSourceShallow, false))
+	}
+	return rows
+}
+
+// buildQuotaRow reads one .claude.json into a row. A missing snapshot is not
+// an error: the row simply carries no windows.
+func buildQuotaRow(scan quotaScan, name, shallowHome, path, source string, active bool) quotaRow {
+	row := quotaRow{
+		Profile: name,
+		Source:  source,
+		Active:  active,
+		Windows: []usage.CachedWindow{},
+	}
+
+	var id *identity.Identity
+	if scan.identityFor != nil {
+		id = scan.identityFor(name, shallowHome)
+	}
+	row.Email, row.Plan = formatIdentityDisplay(id)
+
+	// A missing, older, or corrupt .claude.json all mean the same thing to the
+	// reader: this profile has nothing to report yet.
+	cached, err := usage.ReadCachedUsage(path, scan.now)
+	if err != nil {
+		return row
+	}
+
+	row.AccountUUID = cached.AccountUUID
+	if !cached.FetchedAt.IsZero() {
+		fetched := cached.FetchedAt
+		row.FetchedAt = &fetched
+	}
+	row.Windows = cached.Windows
+	return row
+}
+
+// quotaIdentity is the production identity lookup: the vault's stored
+// credentials for a vault profile, the profile's own HOME for a shallow one.
+func quotaIdentity(name, shallowHome string) *identity.Identity {
+	if shallowHome != "" {
+		id, err := identity.ExtractFromClaudeCredentials(filepath.Join(shallowHome, ".claude", ".credentials.json"))
+		if err != nil {
+			return nil
+		}
+		normalizeIdentityPlan(id)
+		return id
+	}
+	return getVaultIdentity("claude", name)
+}
+
+// liveClaudeJSONPath is the .claude.json Claude Code writes for whichever
+// account is currently active, resolved the same way the rest of caam resolves
+// Claude's auth files.
+func liveClaudeJSONPath() string {
+	for _, f := range authfile.ClaudeAuthFiles().Files {
+		if filepath.Base(f.Path) == ".claude.json" {
+			return f.Path
+		}
+	}
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".claude.json")
+}
+
+func renderQuotaJSON(w io.Writer, rows []quotaRow) error {
+	if rows == nil {
+		rows = []quotaRow{}
+	}
+	data, err := json.MarshalIndent(rows, "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(w, string(data))
+	return err
+}
+
+// renderQuotaTable writes the dashboard. Bars are colored only when color is
+// true (stdout is a TTY); the table is laid out in plain text first so the
+// escape sequences can never disturb column alignment.
+func renderQuotaTable(w io.Writer, rows []quotaRow, now time.Time, color bool) error {
+	if len(rows) == 0 {
+		_, err := fmt.Fprintln(w, "No Claude profiles found.")
+		return err
+	}
+
+	var table bytes.Buffer
+	tw := tabwriter.NewWriter(&table, 0, 0, 2, ' ', 0)
+
+	fmt.Fprintf(tw, "PROFILE\tEMAIL\tPLAN\t5H\tWEEKLY\t%s\tRESETS\tAS OF\n", strings.ToUpper(quotaScopedTitle(rows)))
+
+	// bars[i] holds the plain bar cells of the i-th data line, in the order
+	// they appear, so they can be colorized after the layout is fixed.
+	bars := make([][]quotaBarCell, len(rows))
+
+	for i, row := range rows {
+		name := "  " + row.Profile
+		if row.Active {
+			name = "● " + row.Profile
+		}
+		if row.Source == quotaSourceShallow {
+			name += " (shallow)"
+		}
+
+		if len(row.Windows) == 0 {
+			// A trailing, un-tab-terminated cell sits outside the aligned
+			// columns, so an account with no snapshot cannot stretch the table.
+			fmt.Fprintf(tw, "%s\t%s\t%s\tno usage cache yet (run a session)\n", name, row.Email, row.Plan)
+			continue
+		}
+
+		snapshot := row.Source != quotaSourceLive
+		cells := []quotaBarCell{
+			quotaCell(row.Windows, usage.CachedKindSession, snapshot),
+			quotaCell(row.Windows, usage.CachedKindWeeklyAll, snapshot),
+			quotaCell(row.Windows, usage.CachedKindWeeklyScoped, snapshot),
+		}
+		for _, c := range cells {
+			if c.Percent >= 0 {
+				bars[i] = append(bars[i], c)
+			}
+		}
+
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			name, row.Email, row.Plan, cells[0].Text, cells[1].Text, cells[2].Text,
+			quotaResetsCell(row.Windows), quotaAsOfCell(row, now))
+	}
+
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+
+	lines := strings.Split(strings.TrimRight(table.String(), "\n"), "\n")
+	if color {
+		colorizeQuotaBars(lines, bars)
+	}
+
+	for _, line := range lines {
+		if _, err := fmt.Fprintln(w, line); err != nil {
+			return err
+		}
+	}
+	_, err := fmt.Fprintf(w, "\n%s\n", quotaFooter)
+	return err
+}
+
+// colorizeQuotaBars recolors the already-laid-out bar cells in place.
+func colorizeQuotaBars(lines []string, bars [][]quotaBarCell) {
+	for i, rowBars := range bars {
+		line := i + 1 // line 0 is the header
+		if line >= len(lines) {
+			break
+		}
+		lines[line] = colorizeQuotaLine(lines[line], rowBars, func(c quotaBarCell) string {
+			return quotaBarStyle(c.Percent).Render(c.Text)
+		})
+	}
+}
+
+// colorizeQuotaLine replaces each cell's plain text with paint(cell), scanning
+// left to right from the end of the previous match. Two cells on one row can
+// render identically (two windows at 0%, say), so a search that restarts from
+// the beginning of the line would land inside the cell already painted.
+func colorizeQuotaLine(line string, cells []quotaBarCell, paint func(quotaBarCell) string) string {
+	var out strings.Builder
+	rest := line
+	for _, cell := range cells {
+		idx := strings.Index(rest, cell.Text)
+		if idx < 0 {
+			continue
+		}
+		out.WriteString(rest[:idx])
+		out.WriteString(paint(cell))
+		rest = rest[idx+len(cell.Text):]
+	}
+	out.WriteString(rest)
+	return out.String()
+}
+
+// quotaBarStyle grades a bar by how much of the window is spent.
+func quotaBarStyle(percent int) lipgloss.Style {
+	switch {
+	case percent < 50:
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("2"))
+	case percent < 80:
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("3"))
+	default:
+		return lipgloss.NewStyle().Foreground(lipgloss.Color("1"))
+	}
+}
+
+// quotaBarCell is a rendered bar and the percentage it stands for. Percent is
+// -1 when the account has no such window, so the cell is a plain dash.
+type quotaBarCell struct {
+	Text    string
+	Percent int
+}
+
+// quotaCell renders one window as a bar plus its percentage. Figures from a
+// frozen snapshot are prefixed with "~": they are as of the AS OF column, not
+// as of now.
+func quotaCell(windows []usage.CachedWindow, kind string, snapshot bool) quotaBarCell {
+	for _, w := range windows {
+		if w.Kind != kind {
+			continue
+		}
+		marker := " "
+		if snapshot {
+			marker = "~"
+		}
+		return quotaBarCell{
+			Text:    fmt.Sprintf("%s %s%3d%%", quotaBar(w.Percent), marker, w.Percent),
+			Percent: w.Percent,
+		}
+	}
+	return quotaBarCell{Text: "-", Percent: -1}
+}
+
+// quotaResetsCell shows when the weekly window rolls over: the deadline that
+// actually shapes a week of work.
+func quotaResetsCell(windows []usage.CachedWindow) string {
+	for _, w := range windows {
+		if w.Kind == usage.CachedKindWeeklyAll && w.ResetsAt != nil {
+			return w.ResetsAt.Local().Format("Mon Jan 2 15:04")
+		}
+	}
+	return "-"
+}
+
+func quotaAsOfCell(row quotaRow, now time.Time) string {
+	if row.FetchedAt == nil {
+		return "-"
+	}
+	age := now.Sub(*row.FetchedAt)
+	if age < 0 {
+		age = 0
+	}
+	return formatQuotaAge(age)
+}
+
+// quotaScopedTitle names the per-model column after whichever model the
+// accounts' weekly_scoped windows track.
+func quotaScopedTitle(rows []quotaRow) string {
+	for _, row := range rows {
+		for _, w := range row.Windows {
+			if w.Kind == usage.CachedKindWeeklyScoped && w.Label != "" && w.Label != usage.CachedKindWeeklyScoped {
+				return w.Label
+			}
+		}
+	}
+	return "model"
+}
+
+// quotaBar draws a percentage as a fixed-width bar.
+func quotaBar(percent int) string {
+	if percent < 0 {
+		percent = 0
+	}
+	if percent > 100 {
+		percent = 100
+	}
+	filled := (percent*quotaBarWidth + 50) / 100
+	if filled > quotaBarWidth {
+		filled = quotaBarWidth
+	}
+	return strings.Repeat("█", filled) + strings.Repeat("░", quotaBarWidth-filled)
+}
+
+// formatQuotaAge renders how stale a snapshot is, coarsely: the reader only
+// needs to know whether to trust it.
+func formatQuotaAge(age time.Duration) string {
+	switch {
+	case age < time.Minute:
+		return "just now"
+	case age < time.Hour:
+		return fmt.Sprintf("%dm ago", int(age.Minutes()))
+	case age < 24*time.Hour:
+		return fmt.Sprintf("%dh ago", int(age.Hours()))
+	default:
+		return fmt.Sprintf("%dd ago", int(age.Hours())/24)
+	}
+}

--- a/cmd/caam/cmd/quota_test.go
+++ b/cmd/caam/cmd/quota_test.go
@@ -1,0 +1,335 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/authfile"
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/shallow"
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/usage"
+)
+
+// quotaTestNow is the reference clock for quota rendering tests.
+var quotaTestNow = time.Date(2026, 9, 1, 20, 0, 0, 0, time.UTC)
+
+func quotaTestTime(t *testing.T, value string) *time.Time {
+	t.Helper()
+	ts, err := time.Parse(time.RFC3339, value)
+	require.NoError(t, err)
+	return &ts
+}
+
+// quotaTestRows returns one row of each kind the table has to render: a live
+// active profile, a frozen vault snapshot, a shallow profile, and a profile
+// that has never run a session.
+func quotaTestRows(t *testing.T) []quotaRow {
+	t.Helper()
+	fetched := quotaTestNow.Add(-3 * time.Minute)
+	stale := quotaTestNow.Add(-50 * time.Hour)
+
+	return []quotaRow{
+		{
+			Profile:     "work",
+			Email:       "n/a",
+			Plan:        "Pro",
+			Source:      quotaSourceLive,
+			Active:      true,
+			AccountUUID: "0552fa96-40f9-4b38-a33a-0d5ac585167d",
+			FetchedAt:   &fetched,
+			Windows: []usage.CachedWindow{
+				{Kind: usage.CachedKindSession, Label: "5h", Percent: 53, ResetsAt: quotaTestTime(t, "2026-09-01T22:50:00Z")},
+				{Kind: usage.CachedKindWeeklyAll, Label: "weekly", Percent: 11, ResetsAt: quotaTestTime(t, "2026-09-04T06:00:00Z")},
+				{Kind: usage.CachedKindWeeklyScoped, Label: "Fable", Percent: 19, ResetsAt: quotaTestTime(t, "2026-09-04T06:00:00Z")},
+			},
+		},
+		{
+			Profile:     "personal",
+			Email:       "n/a",
+			Plan:        "Pro",
+			Source:      quotaSourceSnapshot,
+			AccountUUID: "9fc5c17d-a950-4bd0-b3c6-c1c9e7a9b452",
+			FetchedAt:   &stale,
+			Windows: []usage.CachedWindow{
+				{Kind: usage.CachedKindSession, Label: "5h", Percent: 0, Rolled: true, ResetsAt: quotaTestTime(t, "2026-09-01T10:00:00Z")},
+				{Kind: usage.CachedKindWeeklyAll, Label: "weekly", Percent: 88, ResetsAt: quotaTestTime(t, "2026-09-02T18:59:59Z")},
+				{Kind: usage.CachedKindWeeklyScoped, Label: "Fable", Percent: 96},
+			},
+		},
+		{
+			Profile: "spare",
+			Email:   "unknown",
+			Plan:    "unknown",
+			Source:  quotaSourceShallow,
+			Windows: []usage.CachedWindow{},
+		},
+	}
+}
+
+func TestQuotaTableRendersEveryRowKind(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, renderQuotaTable(&buf, quotaTestRows(t), quotaTestNow, false))
+	out := buf.String()
+
+	assert.Contains(t, out, "PROFILE")
+	assert.Contains(t, out, "EMAIL")
+	assert.Contains(t, out, "PLAN")
+	assert.Contains(t, out, "5H")
+	assert.Contains(t, out, "WEEKLY")
+	assert.Contains(t, out, "FABLE", "the model column is titled from the weekly_scoped scope")
+	assert.Contains(t, out, "RESETS")
+	assert.Contains(t, out, "AS OF")
+
+	assert.Contains(t, out, "● work", "the active profile is marked")
+	assert.Contains(t, out, "spare (shallow)", "shallow rows are tagged")
+	assert.Contains(t, out, "no usage cache yet (run a session)")
+
+	assert.Contains(t, out, "█", "percentages render as bars")
+	assert.Contains(t, out, "░")
+	assert.Contains(t, out, " 53%")
+	assert.Contains(t, out, "~ 88%", "a snapshot row marks its percentages as second-hand")
+	assert.NotContains(t, out, "~ 53%", "the live row is not marked as a snapshot")
+
+	assert.Contains(t, out, "3m ago")
+	assert.Contains(t, out, "2d ago")
+	assert.Contains(t, out, "usage as cached by Claude Code")
+	assert.Contains(t, out, "No network.")
+}
+
+func TestQuotaTableIsPlainWithoutColor(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, renderQuotaTable(&buf, quotaTestRows(t), quotaTestNow, false))
+	assert.NotContains(t, buf.String(), "\x1b[", "no ANSI escapes when stdout is not a TTY")
+}
+
+func TestQuotaTableColorsBarsWhenEnabled(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, renderQuotaTable(&buf, quotaTestRows(t), quotaTestNow, true))
+	out := buf.String()
+	assert.Contains(t, out, "█", "bars survive colorization")
+	assert.Contains(t, out, "no usage cache yet (run a session)")
+}
+
+func TestQuotaTableColumnsStayAligned(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, renderQuotaTable(&buf, quotaTestRows(t), quotaTestNow, false))
+
+	var dataLines []string
+	for _, line := range strings.Split(buf.String(), "\n") {
+		if strings.HasPrefix(line, "● work") || strings.HasPrefix(line, "  personal") {
+			dataLines = append(dataLines, line)
+		}
+	}
+	require.Len(t, dataLines, 2)
+
+	// Both rows carry full bar cells, so the "AS OF" column must start in the
+	// same display column on each. Compare rune offsets: the active marker and
+	// the bar blocks are multi-byte.
+	first := utf8.RuneCountInString(dataLines[0][:strings.Index(dataLines[0], "3m ago")])
+	second := utf8.RuneCountInString(dataLines[1][:strings.Index(dataLines[1], "2d ago")])
+	assert.Equal(t, first, second, "bar columns must keep a fixed width")
+}
+
+func TestQuotaTableEmptyVault(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, renderQuotaTable(&buf, nil, quotaTestNow, false))
+	assert.Contains(t, buf.String(), "No Claude profiles found.")
+}
+
+func TestQuotaJSONShape(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, renderQuotaJSON(&buf, quotaTestRows(t)))
+
+	var decoded []map[string]any
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &decoded))
+	require.Len(t, decoded, 3)
+
+	live := decoded[0]
+	assert.Equal(t, "work", live["profile"])
+	assert.Equal(t, "n/a", live["email"])
+	assert.Equal(t, "Pro", live["plan"])
+	assert.Equal(t, "live", live["source"])
+	assert.Equal(t, true, live["active"])
+	assert.Equal(t, "0552fa96-40f9-4b38-a33a-0d5ac585167d", live["account_uuid"])
+	assert.NotNil(t, live["fetched_at"])
+
+	windows, ok := live["windows"].([]any)
+	require.True(t, ok)
+	require.Len(t, windows, 3)
+	session := windows[0].(map[string]any)
+	assert.Equal(t, "session", session["kind"])
+	assert.Equal(t, "5h", session["label"])
+	assert.Equal(t, float64(53), session["percent"])
+	assert.Equal(t, false, session["rolled"])
+	assert.NotNil(t, session["resets_at"])
+
+	snapshot := decoded[1]
+	assert.Equal(t, "snapshot", snapshot["source"])
+	assert.Equal(t, false, snapshot["active"])
+	rolled := snapshot["windows"].([]any)[0].(map[string]any)
+	assert.Equal(t, true, rolled["rolled"])
+	assert.Equal(t, float64(0), rolled["percent"])
+
+	missing := decoded[2]
+	assert.Equal(t, "shallow", missing["source"])
+	assert.Nil(t, missing["fetched_at"])
+	assert.Empty(t, missing["windows"])
+}
+
+func TestQuotaUnknownProviderFails(t *testing.T) {
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("json", false, "")
+	var buf bytes.Buffer
+	cmd.SetOut(&buf)
+	cmd.SetErr(&buf)
+
+	err := runQuota(cmd, []string{"codex"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no local usage cache for codex")
+	assert.Equal(t, 1, ExitCode(err))
+}
+
+func TestCollectQuotaRowsReadsLiveSnapshotAndShallow(t *testing.T) {
+	vaultDir := t.TempDir()
+	homeDir := t.TempDir()
+	shallowBase := filepath.Join(t.TempDir(), "orch-homes")
+
+	writeQuotaCache(t, filepath.Join(homeDir, ".claude.json"), 1788292800000, "live-uuid", 53)
+	writeQuotaCache(t, filepath.Join(vaultDir, "claude", "work", ".claude.json"), 1788292800000, "live-uuid", 99)
+	writeQuotaCache(t, filepath.Join(vaultDir, "claude", "personal", ".claude.json"), 1788200000000, "snap-uuid", 12)
+	require.NoError(t, os.MkdirAll(filepath.Join(vaultDir, "claude", "fresh"), 0o755))
+
+	shallowHome := filepath.Join(shallowBase, "spare")
+	writeQuotaCache(t, filepath.Join(shallowHome, ".claude.json"), 1788200000000, "shallow-uuid", 7)
+	writeShallowMeta(t, shallowHome, "spare", "claude")
+	mgr, err := shallow.NewManager(shallowBase, homeDir)
+	require.NoError(t, err)
+
+	rows, err := collectQuotaRows(quotaScan{
+		vault:          authfile.NewVault(vaultDir),
+		liveClaudeJSON: filepath.Join(homeDir, ".claude.json"),
+		active:         "work",
+		shallowMgr:     mgr,
+		now:            quotaTestNow,
+	})
+	require.NoError(t, err)
+	require.Len(t, rows, 4)
+
+	byName := map[string]quotaRow{}
+	for _, r := range rows {
+		byName[r.Profile] = r
+	}
+
+	work := byName["work"]
+	assert.Equal(t, quotaSourceLive, work.Source)
+	assert.True(t, work.Active)
+	assert.Equal(t, "live-uuid", work.AccountUUID)
+	assert.Equal(t, 53, work.Windows[0].Percent, "the active profile reads the live file, not the frozen snapshot")
+
+	personal := byName["personal"]
+	assert.Equal(t, quotaSourceSnapshot, personal.Source)
+	assert.False(t, personal.Active)
+	assert.Equal(t, 12, personal.Windows[0].Percent)
+
+	fresh := byName["fresh"]
+	assert.Equal(t, quotaSourceSnapshot, fresh.Source)
+	assert.Empty(t, fresh.Windows, "a profile with no cache yet has no windows")
+	assert.Nil(t, fresh.FetchedAt)
+
+	spare := byName["spare"]
+	assert.Equal(t, quotaSourceShallow, spare.Source)
+	assert.Equal(t, 7, spare.Windows[0].Percent)
+}
+
+func TestCollectQuotaRowsUnreadableVault(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "not-a-vault")
+	rows, err := collectQuotaRows(quotaScan{
+		vault:          authfile.NewVault(missing),
+		liveClaudeJSON: filepath.Join(t.TempDir(), ".claude.json"),
+		now:            quotaTestNow,
+	})
+	// An absent vault is empty, not broken: no profiles, no error.
+	require.NoError(t, err)
+	assert.Empty(t, rows)
+}
+
+func TestFormatQuotaAge(t *testing.T) {
+	cases := []struct {
+		age  time.Duration
+		want string
+	}{
+		{0, "just now"},
+		{45 * time.Second, "just now"},
+		{3 * time.Minute, "3m ago"},
+		{5 * time.Hour, "5h ago"},
+		{50 * time.Hour, "2d ago"},
+	}
+	for _, tc := range cases {
+		assert.Equal(t, tc.want, formatQuotaAge(tc.age), "age %v", tc.age)
+	}
+}
+
+func TestQuotaBarWidthAndFill(t *testing.T) {
+	assert.Equal(t, "░░░░░░░░░░", quotaBar(0))
+	assert.Equal(t, "██████████", quotaBar(100))
+	assert.Equal(t, "█████░░░░░", quotaBar(53))
+	assert.Equal(t, "██████████", quotaBar(150), "percentages are clamped")
+}
+
+func writeQuotaCache(t *testing.T, path string, fetchedAtMs int64, accountUUID string, sessionPercent int) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+	payload := map[string]any{
+		"cachedUsageUtilization": map[string]any{
+			"fetchedAtMs": fetchedAtMs,
+			"accountUuid": accountUUID,
+			"utilization": map[string]any{
+				"limits": []map[string]any{
+					{"kind": "session", "percent": sessionPercent, "resets_at": "2026-09-01T22:50:00+00:00"},
+					{"kind": "weekly_all", "percent": 11, "resets_at": "2026-09-04T06:00:00+00:00"},
+					{"kind": "weekly_scoped", "percent": 19, "resets_at": "2026-09-04T06:00:00+00:00",
+						"scope": map[string]any{"model": map[string]any{"display_name": "Fable"}}},
+				},
+			},
+		},
+	}
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+}
+
+func writeShallowMeta(t *testing.T, home, name, provider string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(home, 0o755))
+	meta := shallow.Meta{Name: name, Provider: provider, RealHome: filepath.Dir(home), Version: 1}
+	data, err := json.Marshal(meta)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(filepath.Join(home, shallow.ProfileMetaFilename), data, 0o600))
+}
+
+// TestColorizeQuotaLine_IdenticalCellsPaintedIndependently pins the bug where a
+// second identical bar on the same row was matched inside the first, already
+// painted, cell.
+func TestColorizeQuotaLine_IdenticalCellsPaintedIndependently(t *testing.T) {
+	zero := quotaBarCell{Text: "░░░░░░░░░░ ~  0%", Percent: 0}
+	high := quotaBarCell{Text: "█████████░ ~ 90%", Percent: 90}
+	line := "  acct  n/a  Pro  " + zero.Text + "  " + zero.Text + "  " + high.Text + "  Mon Jan 1 00:00  3h ago"
+
+	got := colorizeQuotaLine(line, []quotaBarCell{zero, zero, high}, func(c quotaBarCell) string {
+		return "<" + c.Text + ">"
+	})
+
+	want := "  acct  n/a  Pro  <" + zero.Text + ">  <" + zero.Text + ">  <" + high.Text + ">  Mon Jan 1 00:00  3h ago"
+	if got != want {
+		t.Fatalf("colorizeQuotaLine() =\n%s\nwant\n%s", got, want)
+	}
+}

--- a/cmd/caam/cmd/quota_test.go
+++ b/cmd/caam/cmd/quota_test.go
@@ -44,6 +44,7 @@ func quotaTestRows(t *testing.T) []quotaRow {
 			Plan:        "Pro",
 			Source:      quotaSourceLive,
 			Active:      true,
+			Lanes:       []string{"active"},
 			AccountUUID: "0552fa96-40f9-4b38-a33a-0d5ac585167d",
 			FetchedAt:   &fetched,
 			Windows: []usage.CachedWindow{
@@ -57,6 +58,7 @@ func quotaTestRows(t *testing.T) []quotaRow {
 			Email:       "n/a",
 			Plan:        "Pro",
 			Source:      quotaSourceSnapshot,
+			Lanes:       []string{"vault"},
 			AccountUUID: "9fc5c17d-a950-4bd0-b3c6-c1c9e7a9b452",
 			FetchedAt:   &stale,
 			Windows: []usage.CachedWindow{
@@ -70,6 +72,7 @@ func quotaTestRows(t *testing.T) []quotaRow {
 			Email:   "unknown",
 			Plan:    "unknown",
 			Source:  quotaSourceShallow,
+			Lanes:   []string{"shallow"},
 			Windows: []usage.CachedWindow{},
 		},
 	}
@@ -89,8 +92,9 @@ func TestQuotaTableRendersEveryRowKind(t *testing.T) {
 	assert.Contains(t, out, "RESETS")
 	assert.Contains(t, out, "AS OF")
 
-	assert.Contains(t, out, "● work", "the active profile is marked")
-	assert.Contains(t, out, "spare (shallow)", "shallow rows are tagged")
+	assert.Contains(t, out, "* work", "the active profile is marked")
+	assert.Contains(t, out, "LANE")
+	assert.Contains(t, out, "shallow", "shallow rows show their lane")
 	assert.Contains(t, out, "no usage cache yet (run a session)")
 
 	assert.Contains(t, out, "█", "percentages render as bars")
@@ -125,7 +129,7 @@ func TestQuotaTableColumnsStayAligned(t *testing.T) {
 
 	var dataLines []string
 	for _, line := range strings.Split(buf.String(), "\n") {
-		if strings.HasPrefix(line, "● work") || strings.HasPrefix(line, "  personal") {
+		if strings.HasPrefix(line, "* work") || strings.HasPrefix(line, "  personal") {
 			dataLines = append(dataLines, line)
 		}
 	}
@@ -160,6 +164,7 @@ func TestQuotaJSONShape(t *testing.T) {
 	assert.Equal(t, "live", live["source"])
 	assert.Equal(t, true, live["active"])
 	assert.Equal(t, "0552fa96-40f9-4b38-a33a-0d5ac585167d", live["account_uuid"])
+	assert.Equal(t, []any{"active"}, live["lanes"])
 	assert.NotNil(t, live["fetched_at"])
 
 	windows, ok := live["windows"].([]any)
@@ -332,4 +337,44 @@ func TestColorizeQuotaLine_IdenticalCellsPaintedIndependently(t *testing.T) {
 	if got != want {
 		t.Fatalf("colorizeQuotaLine() =\n%s\nwant\n%s", got, want)
 	}
+}
+
+// TestMergeQuotaRowsFoldsLanesOfOneAccount pins the account-centric view: a
+// vault profile and a shallow profile logged into the same account are one
+// row, named after the vault profile, carrying the freshest numbers and both
+// lanes. Different accounts, and rows with no uuid, stay separate.
+func TestMergeQuotaRowsFoldsLanesOfOneAccount(t *testing.T) {
+	old := quotaTestNow.Add(-3 * time.Hour)
+	fresh := quotaTestNow.Add(-2 * time.Minute)
+	rows := []quotaRow{
+		{Profile: "vadim", Source: quotaSourceSnapshot, AccountUUID: "u1", FetchedAt: &old,
+			Windows: []usage.CachedWindow{{Kind: usage.CachedKindWeeklyAll, Percent: 29}}},
+		{Profile: "adriana", Source: quotaSourceLive, Active: true, AccountUUID: "u2", FetchedAt: &fresh,
+			Windows: []usage.CachedWindow{{Kind: usage.CachedKindWeeklyAll, Percent: 11}}},
+		{Profile: "vadim", Source: quotaSourceShallow, AccountUUID: "u1", FetchedAt: &fresh,
+			Windows: []usage.CachedWindow{{Kind: usage.CachedKindWeeklyAll, Percent: 31}}},
+		{Profile: "sw-adriana", Source: quotaSourceShallow, AccountUUID: "u2", FetchedAt: &old,
+			Windows: []usage.CachedWindow{{Kind: usage.CachedKindWeeklyAll, Percent: 9}}},
+		{Profile: "blank", Source: quotaSourceSnapshot, Windows: []usage.CachedWindow{}},
+	}
+
+	merged := mergeQuotaRows(rows)
+	require.Len(t, merged, 3)
+
+	vadim := merged[0]
+	assert.Equal(t, "vadim", vadim.Profile)
+	assert.Equal(t, quotaSourceShallow, vadim.Source, "the fresher shallow numbers win")
+	assert.Equal(t, 31, vadim.Windows[0].Percent)
+	assert.Equal(t, []string{"vault", "shallow"}, vadim.Lanes)
+	assert.False(t, vadim.Active)
+
+	adriana := merged[1]
+	assert.Equal(t, "adriana", adriana.Profile, "the vault name names the row even when a shallow lane exists")
+	assert.Equal(t, quotaSourceLive, adriana.Source, "the live numbers are fresher than the shallow snapshot")
+	assert.Equal(t, 11, adriana.Windows[0].Percent)
+	assert.True(t, adriana.Active)
+	assert.Equal(t, []string{"active", "shallow(sw-adriana)"}, adriana.Lanes)
+
+	assert.Equal(t, "blank", merged[2].Profile)
+	assert.Equal(t, []string{"vault"}, merged[2].Lanes)
 }

--- a/internal/usage/cached.go
+++ b/internal/usage/cached.go
@@ -1,0 +1,219 @@
+package usage
+
+// Cached usage: reading the utilization snapshot Claude Code itself writes.
+//
+// Claude Code stores the usage figures it last received from the API in the
+// top-level "cachedUsageUtilization" key of ~/.claude.json, refreshed by that
+// account's own sessions. Reading it costs nothing and, unlike the live
+// fetchers in this package, never presents a bearer token: no account is
+// touched by another account's process, which is exactly the shared-credential
+// pattern that gets subscriptions revoked.
+//
+// This file deliberately imports nothing that talks to the network.
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+)
+
+// Window kinds emitted by Claude Code in the cached utilization payload.
+const (
+	// CachedKindSession is the rolling 5-hour window.
+	CachedKindSession = "session"
+	// CachedKindWeeklyAll is the weekly cap covering every model.
+	CachedKindWeeklyAll = "weekly_all"
+	// CachedKindWeeklyScoped is the weekly cap for one model (see the window's
+	// Label for which one).
+	CachedKindWeeklyScoped = "weekly_scoped"
+)
+
+// ErrNoCachedUsage reports that a .claude.json holds no usage snapshot: the
+// file is absent, predates the cache, or carries an empty limits array. It is
+// an expected state for a profile that has not run a session yet, not a fault.
+var ErrNoCachedUsage = errors.New("no cached usage utilization")
+
+// CachedWindow is one rate-limit window from the cached snapshot.
+type CachedWindow struct {
+	// Kind is the raw kind from Claude Code ("session", "weekly_all", ...).
+	Kind string `json:"kind"`
+
+	// Label is the human-facing name: "5h", "weekly", or, for a model-scoped
+	// weekly window, the model's display name (e.g. "Fable").
+	Label string `json:"label"`
+
+	// Percent is the share of the window consumed, 0-100. A rolled window
+	// reads 0 regardless of what the snapshot recorded.
+	Percent int `json:"percent"`
+
+	// ResetsAt is when the window rolls over; nil when the snapshot omits it.
+	ResetsAt *time.Time `json:"resets_at"`
+
+	// Rolled is true when ResetsAt has already passed, meaning the recorded
+	// percentage describes a window that has since emptied.
+	Rolled bool `json:"rolled"`
+}
+
+// CachedUsage is the usage snapshot Claude Code cached for one account.
+type CachedUsage struct {
+	// AccountUUID identifies the account the snapshot belongs to.
+	AccountUUID string `json:"account_uuid"`
+
+	// FetchedAt is when Claude Code last refreshed the snapshot; zero when the
+	// snapshot omits the timestamp.
+	FetchedAt time.Time `json:"fetched_at"`
+
+	// Windows are the rate-limit windows, in the order Claude Code recorded.
+	Windows []CachedWindow `json:"windows"`
+}
+
+// cachedUsageFile is the slice of .claude.json this package cares about.
+type cachedUsageFile struct {
+	Cached *cachedUsageBlock `json:"cachedUsageUtilization"`
+}
+
+type cachedUsageBlock struct {
+	FetchedAtMs int64  `json:"fetchedAtMs"`
+	AccountUUID string `json:"accountUuid"`
+	Utilization struct {
+		Limits []cachedLimit `json:"limits"`
+	} `json:"utilization"`
+}
+
+type cachedLimit struct {
+	Kind     string  `json:"kind"`
+	Percent  *int    `json:"percent"`
+	ResetsAt *string `json:"resets_at"`
+	Scope    *struct {
+		Model *struct {
+			DisplayName string `json:"display_name"`
+		} `json:"model"`
+	} `json:"scope"`
+}
+
+// modelName is the display name of the model this limit is scoped to, if any.
+func (l cachedLimit) modelName() string {
+	if l.Scope == nil || l.Scope.Model == nil {
+		return ""
+	}
+	return l.Scope.Model.DisplayName
+}
+
+// ReadCachedUsage reads the usage snapshot from a .claude.json at path. A
+// missing or unreadable file yields ErrNoCachedUsage, since a profile with no
+// file simply has nothing cached yet.
+func ReadCachedUsage(path string, now time.Time) (*CachedUsage, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrNoCachedUsage, path)
+	}
+	return ParseCachedUsage(data, now)
+}
+
+// ParseCachedUsage extracts the usage snapshot from the bytes of a
+// .claude.json. Windows whose reset time has already passed are reported as
+// rolled and read 0%: nothing has run against them since they emptied.
+// Malformed JSON is an error; a well-formed file without a snapshot yields
+// ErrNoCachedUsage.
+func ParseCachedUsage(data []byte, now time.Time) (*CachedUsage, error) {
+	var file cachedUsageFile
+	if err := json.Unmarshal(data, &file); err != nil {
+		return nil, fmt.Errorf("parse .claude.json: %w", err)
+	}
+	if file.Cached == nil || len(file.Cached.Utilization.Limits) == 0 {
+		return nil, ErrNoCachedUsage
+	}
+
+	out := &CachedUsage{AccountUUID: file.Cached.AccountUUID}
+	if file.Cached.FetchedAtMs > 0 {
+		out.FetchedAt = time.UnixMilli(file.Cached.FetchedAtMs)
+	}
+
+	for _, limit := range file.Cached.Utilization.Limits {
+		w := CachedWindow{Kind: limit.Kind, Label: cachedWindowLabel(limit.Kind, limit.modelName())}
+		if limit.Percent != nil {
+			w.Percent = clampPercent(*limit.Percent)
+		}
+		if limit.ResetsAt != nil {
+			if ts, err := time.Parse(time.RFC3339, *limit.ResetsAt); err == nil {
+				w.ResetsAt = &ts
+				if !ts.After(now) {
+					w.Rolled = true
+					w.Percent = 0
+				}
+			}
+		}
+		out.Windows = append(out.Windows, w)
+	}
+
+	return out, nil
+}
+
+// Window returns the first window of the given kind, or nil when the snapshot
+// has none.
+func (c *CachedUsage) Window(kind string) *CachedWindow {
+	if c == nil {
+		return nil
+	}
+	for i := range c.Windows {
+		if c.Windows[i].Kind == kind {
+			return &c.Windows[i]
+		}
+	}
+	return nil
+}
+
+// ScopedLabel returns the model display name of the model-scoped weekly
+// window, or "" when the snapshot has no such window. Callers use it to title
+// the per-model column of a table spanning several accounts.
+func (c *CachedUsage) ScopedLabel() string {
+	w := c.Window(CachedKindWeeklyScoped)
+	if w == nil || w.Label == CachedKindWeeklyScoped {
+		return ""
+	}
+	return w.Label
+}
+
+// Age reports how long ago the snapshot was refreshed. It is 0 when the
+// snapshot carries no fetch timestamp.
+func (c *CachedUsage) Age(now time.Time) time.Duration {
+	if c == nil || c.FetchedAt.IsZero() {
+		return 0
+	}
+	age := now.Sub(c.FetchedAt)
+	if age < 0 {
+		return 0
+	}
+	return age
+}
+
+// cachedWindowLabel maps a window kind (plus the model it is scoped to, if
+// any) to the name shown to the user.
+func cachedWindowLabel(kind, model string) string {
+	switch kind {
+	case CachedKindSession:
+		return "5h"
+	case CachedKindWeeklyAll:
+		return "weekly"
+	case CachedKindWeeklyScoped:
+		if model != "" {
+			return model
+		}
+		return kind
+	default:
+		return kind
+	}
+}
+
+func clampPercent(p int) int {
+	switch {
+	case p < 0:
+		return 0
+	case p > 100:
+		return 100
+	default:
+		return p
+	}
+}

--- a/internal/usage/cached_test.go
+++ b/internal/usage/cached_test.go
@@ -1,0 +1,204 @@
+package usage
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// fixedNow is the reference "current time" for cached-usage tests. Windows that
+// reset before it have rolled; windows that reset after it are still counting.
+var fixedNow = time.Date(2026, 9, 1, 20, 0, 0, 0, time.UTC)
+
+const fullCacheJSON = `{
+  "userID": "irrelevant",
+  "cachedUsageUtilization": {
+    "fetchedAtMs": 1788292800000,
+    "accountUuid": "0552fa96-40f9-4b38-a33a-0d5ac585167d",
+    "utilization": {
+      "limits": [
+        {"kind": "session",       "percent": 53, "resets_at": "2026-09-01T22:50:00.110099+00:00", "scope": null},
+        {"kind": "weekly_all",    "percent": 11, "resets_at": "2026-09-04T06:00:00.110125+00:00", "scope": null},
+        {"kind": "weekly_scoped", "percent": 19, "resets_at": "2026-09-04T06:00:00.110393+00:00",
+         "scope": {"model": {"id": null, "display_name": "Fable"}, "surface": null}}
+      ]
+    }
+  }
+}`
+
+func TestParseCachedUsageFullSnapshot(t *testing.T) {
+	got, err := ParseCachedUsage([]byte(fullCacheJSON), fixedNow)
+	if err != nil {
+		t.Fatalf("ParseCachedUsage: %v", err)
+	}
+	if got.AccountUUID != "0552fa96-40f9-4b38-a33a-0d5ac585167d" {
+		t.Errorf("AccountUUID = %q", got.AccountUUID)
+	}
+	wantFetched := time.UnixMilli(1788292800000)
+	if !got.FetchedAt.Equal(wantFetched) {
+		t.Errorf("FetchedAt = %v, want %v", got.FetchedAt, wantFetched)
+	}
+	if len(got.Windows) != 3 {
+		t.Fatalf("len(Windows) = %d, want 3", len(got.Windows))
+	}
+
+	session := got.Window(CachedKindSession)
+	if session == nil {
+		t.Fatal("no session window")
+	}
+	if session.Percent != 53 || session.Rolled {
+		t.Errorf("session = %+v, want 53%% and not rolled", session)
+	}
+	if session.Label != "5h" {
+		t.Errorf("session label = %q, want 5h", session.Label)
+	}
+	if session.ResetsAt == nil || !session.ResetsAt.Equal(time.Date(2026, 9, 1, 22, 50, 0, 110099000, time.UTC)) {
+		t.Errorf("session ResetsAt = %v", session.ResetsAt)
+	}
+
+	weekly := got.Window(CachedKindWeeklyAll)
+	if weekly == nil || weekly.Percent != 11 || weekly.Label != "weekly" {
+		t.Errorf("weekly = %+v, want 11%% labelled weekly", weekly)
+	}
+}
+
+func TestParseCachedUsageWeeklyScopedLabelIsModelDisplayName(t *testing.T) {
+	got, err := ParseCachedUsage([]byte(fullCacheJSON), fixedNow)
+	if err != nil {
+		t.Fatalf("ParseCachedUsage: %v", err)
+	}
+	scoped := got.Window(CachedKindWeeklyScoped)
+	if scoped == nil {
+		t.Fatal("no weekly_scoped window")
+	}
+	if scoped.Label != "Fable" {
+		t.Errorf("scoped label = %q, want the model display name Fable", scoped.Label)
+	}
+	if scoped.Percent != 19 {
+		t.Errorf("scoped percent = %d, want 19", scoped.Percent)
+	}
+	if got.ScopedLabel() != "Fable" {
+		t.Errorf("ScopedLabel() = %q, want Fable", got.ScopedLabel())
+	}
+}
+
+func TestParseCachedUsageRolledWindowReadsZero(t *testing.T) {
+	// resets_at is before now: the window rolled, so nothing has been used since.
+	const rolled = `{"cachedUsageUtilization": {"fetchedAtMs": 1788200000000, "accountUuid": "u",
+	  "utilization": {"limits": [
+	    {"kind": "session", "percent": 92, "resets_at": "2026-09-01T10:00:00+00:00", "scope": null}
+	  ]}}}`
+
+	got, err := ParseCachedUsage([]byte(rolled), fixedNow)
+	if err != nil {
+		t.Fatalf("ParseCachedUsage: %v", err)
+	}
+	session := got.Window(CachedKindSession)
+	if session == nil {
+		t.Fatal("no session window")
+	}
+	if session.Percent != 0 {
+		t.Errorf("percent = %d, want 0 for a window whose reset has passed", session.Percent)
+	}
+	if !session.Rolled {
+		t.Error("Rolled = false, want true for a window whose reset has passed")
+	}
+}
+
+func TestParseCachedUsageNullResetsAtAndAbsentPercent(t *testing.T) {
+	const partial = `{"cachedUsageUtilization": {"fetchedAtMs": 1788292800000, "accountUuid": "u",
+	  "utilization": {"limits": [
+	    {"kind": "session", "percent": 0, "resets_at": null, "scope": null},
+	    {"kind": "weekly_all", "resets_at": null, "scope": null}
+	  ]}}}`
+
+	got, err := ParseCachedUsage([]byte(partial), fixedNow)
+	if err != nil {
+		t.Fatalf("ParseCachedUsage: %v", err)
+	}
+	session := got.Window(CachedKindSession)
+	if session == nil || session.ResetsAt != nil {
+		t.Errorf("session = %+v, want a nil ResetsAt", session)
+	}
+	if session.Rolled {
+		t.Error("a window with no reset time must not be reported as rolled")
+	}
+	weekly := got.Window(CachedKindWeeklyAll)
+	if weekly == nil || weekly.Percent != 0 {
+		t.Errorf("weekly = %+v, want percent 0 when the field is absent", weekly)
+	}
+	if got.ScopedLabel() != "" {
+		t.Errorf("ScopedLabel() = %q, want empty with no weekly_scoped window", got.ScopedLabel())
+	}
+}
+
+func TestParseCachedUsageMissingKey(t *testing.T) {
+	_, err := ParseCachedUsage([]byte(`{"userID": "x", "projects": {}}`), fixedNow)
+	if !errors.Is(err, ErrNoCachedUsage) {
+		t.Fatalf("err = %v, want ErrNoCachedUsage", err)
+	}
+}
+
+func TestParseCachedUsageEmptyLimitsIsNoCache(t *testing.T) {
+	const empty = `{"cachedUsageUtilization": {"fetchedAtMs": 1788292800000, "utilization": {"limits": []}}}`
+	if _, err := ParseCachedUsage([]byte(empty), fixedNow); !errors.Is(err, ErrNoCachedUsage) {
+		t.Fatalf("err = %v, want ErrNoCachedUsage for an empty limits array", err)
+	}
+}
+
+func TestParseCachedUsageUnknownKindKeepsKindAsLabel(t *testing.T) {
+	const odd = `{"cachedUsageUtilization": {"fetchedAtMs": 1, "utilization": {"limits": [
+	  {"kind": "monthly_experiment", "percent": 7, "resets_at": null}]}}}`
+	got, err := ParseCachedUsage([]byte(odd), fixedNow)
+	if err != nil {
+		t.Fatalf("ParseCachedUsage: %v", err)
+	}
+	w := got.Window("monthly_experiment")
+	if w == nil || w.Label != "monthly_experiment" {
+		t.Errorf("window = %+v, want the raw kind as its label", w)
+	}
+}
+
+func TestParseCachedUsageInvalidJSON(t *testing.T) {
+	if _, err := ParseCachedUsage([]byte(`{not json`), fixedNow); err == nil {
+		t.Fatal("want an error for malformed JSON")
+	} else if errors.Is(err, ErrNoCachedUsage) {
+		t.Fatal("malformed JSON must not be reported as a missing cache")
+	}
+}
+
+func TestReadCachedUsage(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".claude.json")
+	if err := os.WriteFile(path, []byte(fullCacheJSON), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	got, err := ReadCachedUsage(path, fixedNow)
+	if err != nil {
+		t.Fatalf("ReadCachedUsage: %v", err)
+	}
+	if got.AccountUUID == "" || len(got.Windows) != 3 {
+		t.Errorf("got = %+v, want the parsed snapshot", got)
+	}
+}
+
+func TestReadCachedUsageMissingFile(t *testing.T) {
+	_, err := ReadCachedUsage(filepath.Join(t.TempDir(), "absent.json"), fixedNow)
+	if !errors.Is(err, ErrNoCachedUsage) {
+		t.Fatalf("err = %v, want ErrNoCachedUsage for a missing file", err)
+	}
+}
+
+func TestCachedUsageAge(t *testing.T) {
+	c := &CachedUsage{FetchedAt: fixedNow.Add(-90 * time.Minute)}
+	if got := c.Age(fixedNow); got != 90*time.Minute {
+		t.Errorf("Age = %v, want 90m", got)
+	}
+	var missing CachedUsage
+	if got := missing.Age(fixedNow); got != 0 {
+		t.Errorf("Age with no fetch time = %v, want 0", got)
+	}
+}


### PR DESCRIPTION
## Problem

`caam limits` answers "which account still has headroom" by presenting **every** vault profile's bearer token to `api.anthropic.com` from one process. One machine speaking for several accounts at once is the shared-credential shape that gets subscriptions revoked, so users who care about their accounts can't safely run it. But the question is the one that matters most when you run several Max accounts, and `caam_improvement_prompts.md` (Jan 2026) already says it: "we really SHOULD be able to directly look up this usage data so we can really be smart about it."

## Design

The data is already on disk. Claude Code caches each account's utilization in that account's own `.claude.json` under `cachedUsageUtilization` (`fetchedAtMs`, `accountUuid`, `utilization.limits[]` with kinds `session` = 5-hour, `weekly_all`, `weekly_scoped` with the model's display name, each with `percent` and `resets_at`). `caam quota` reads those files and nothing else: no token presented, no request made.

Per profile:
- the **active** vault profile is read from the live `~/.claude.json` (the vault copy froze at switch time);
- every other vault profile from `<vault>/claude/<profile>/.claude.json`;
- shallow profiles from their own HOME, tagged `(shallow)`.

A window whose `resets_at` has passed reads 0% (nothing ran since it emptied). Figures from a frozen snapshot carry a `~` marker and every row shows the snapshot's age, so staleness is visible rather than hidden.

```
PROFILE           EMAIL  PLAN  5H                WEEKLY            FABLE             RESETS           AS OF
● adriana-gmail   n/a    Pro   █████░░░░░   53%  █░░░░░░░░░   11%  ██░░░░░░░░   19%  Fri Sep 4 08:00  20m ago
  adriana-syneto  n/a    Pro   ░░░░░░░░░░ ~  0%  ░░░░░░░░░░ ~  4%  ░░░░░░░░░░ ~  3%  Wed Sep 2 20:59  3h ago
  vadim           n/a    Pro   ░░░░░░░░░░ ~  0%  ███░░░░░░░ ~ 29%  █████░░░░░ ~ 54%  Wed Sep 2 10:00  3h ago

usage as cached by Claude Code; refreshed by that account's own sessions. No network.
```

`--json` emits the same rows with `source` (`live` / `snapshot` / `shallow`), `account_uuid`, `fetched_at`, and each window's `percent`, `resets_at`, `rolled`. `caam quota <other provider>` exits 1 and points at `caam limits`, since only Claude caches usage on disk.

## Implementation

- `internal/usage/cached.go`: parser and model, deliberately network-free.
- `cmd/caam/cmd/quota.go`: cobra command and table. Bars are colored only on a TTY; the table is laid out plain first and bar cells are colorized afterwards so ANSI bytes never disturb tabwriter alignment.
- README: a "Cached Usage: `caam quota`" section.

Not wired into the robot surface (its commands are hand-rolled with a bespoke envelope); happy to add in a follow-up if wanted.

## Tests

`internal/usage/cached_test.go`: full / partial / missing cache, rolled window → 0, null `resets_at`, scoped label. `cmd/caam/cmd/quota_test.go`: live + snapshot + no-cache rows against a temp vault, column alignment across rows, no color off-TTY, `--json` shape, unknown provider exit. All paths via `t.TempDir()`.

Gate: `gofmt -l`, `go vet ./...`, `go build ./cmd/caam`, `go test ./...` (isolated HOME), `go test -race ./internal/usage/...`. The table above is a real run against a real vault.

https://claude.ai/code/session_01UjcKgW7xJGKyA2FH4ypx75
