### PR TITLE
feat(shallow): open an account in this terminal with one command

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,19 @@ A "shallow" `$HOME` per identity: only the auth-bearing files are real, **everyt
 
 **Supported providers:** `claude`, `codex`, and `agy` (Antigravity). Each provider keeps only *its own* identity files real and private; everything else symlinks back to your real `~/`. The provider is inferred from `--from-vault <tool>/<profile>`, or set explicitly with `--tool claude|codex|agy` (defaults to `claude`). On spawn, caam repoints `HOME` at the shallow profile and pins the provider's home var (`CODEX_HOME` / `GEMINI_HOME`) so a stray inherited value can't pull the real identity back in.
 
+**Daily flow.** Day to day this is the whole loop:
+
+```bash
+caam shallow-spawn vadim     # open claude as "vadim" in THIS terminal.
+                             # First time: creates the profile (empty) and the session logs you in.
+caam status                  # which account each tool is on right now
+caam next claude             # rotate the MAIN lane (your real ~/) to the next account
+```
+
+`caam shallow-spawn <name>` with no `-- <cmd>` section runs that profile's own provider CLI (`claude`, `codex`, or `agy`), and creates the profile if it does not exist yet — add `--tool codex|agy` to pick a non-claude layout. Profiles created this way start **empty** on purpose: caam never copies a credential out of the vault on spawn, because two homes sharing one refresh-token family log each other out as soon as Claude rotates the token (issue #19). When you deliberately want a copy, ask for it: `caam shallow-profile create <name> --from-vault <tool>/<profile>`.
+
+**Double-spend rule.** caam refuses to open a shallow `claude` profile that is logged in as the account *already active* in your real `~/.claude.json` — two live sessions would draw down one subscription's quota. Run `claude` directly for that account, or pass `--force`. The check is skipped when either side has no `oauthAccount` recorded (nothing to compare), and for `codex`/`agy`, which keep no comparable account identity on disk.
+
 ```bash
 # Stage credentials in caam's vault first (one-time per account).
 caam backup claude alice@example.com
@@ -202,8 +215,12 @@ Per-provider real (private) files — everything else under the provider's home 
 caam shallow-profile create <name> [--tool claude|codex|agy] [--from-vault <tool>/<profile>] [--from-file <path>] [--force] [--json]
 caam shallow-profile list [--json]
 caam shallow-profile delete <name> [--force] [--json]
+caam shallow-spawn <name>                     # runs the profile's own CLI; creates the profile if new
+caam shallow-spawn <name> --tool codex        # layout for a profile created on first use (default: claude)
+caam shallow-spawn <name> --force             # override the double-spend guard
 caam shallow-spawn <name> -- <cmd> [args...]
 caam shallow-spawn <name> --print-env         # print HOME=... (and CODEX_HOME/GEMINI_HOME) without exec
+                                              # strict dry run: never creates a missing profile, never guards
 caam shallow-spawn <name> --allow-agent-view -- claude   # keep Claude Code Agent View enabled (see note below)
 caam shallow-spawn <name> --effort xhigh -- codex ...    # codex only: injects `-c model_reasoning_effort=xhigh` (codex has no --effort flag)
 ```

--- a/cmd/caam/cmd/shallow.go
+++ b/cmd/caam/cmd/shallow.go
@@ -349,10 +349,46 @@ func init() {
 }
 
 type shallowListItem struct {
-	Name           string    `json:"name"`
-	Path           string    `json:"path"`
+	Name     string `json:"name"`
+	Path     string `json:"path"`
+	Provider string `json:"provider,omitempty"`
+	// LoggedIn reports whether the profile's private credential file holds a
+	// credential right now; Identity names the account (claude only) from
+	// the profile's own .claude.json. Both are read live, unlike
+	// CredentialFrom, which only records where the credential came from at
+	// creation time and stays "(none)" for a profile that logged in later.
+	LoggedIn       bool      `json:"logged_in"`
+	Identity       string    `json:"identity,omitempty"`
 	CredentialFrom string    `json:"credential_from,omitempty"`
 	CreatedAt      time.Time `json:"created_at,omitempty"`
+}
+
+// shallowLoginState reads a shallow profile's live login state: its provider,
+// whether its private credential file holds a credential, and (claude only)
+// which account that is.
+func shallowLoginState(mgr *shallow.Manager, name, home string) (provider string, loggedIn bool, identity string) {
+	provider, _ = mgr.ResolveProvider(name)
+	credPath, err := mgr.CredentialPath(name)
+	if err != nil {
+		return provider, false, ""
+	}
+	loggedIn = shallowCredentialPresent(credPath)
+	if loggedIn && shallow.NormalizeProvider(provider) == "claude" {
+		identity = authfile.ClaudeIdentityLabel(authfile.ClaudeIdentityKeysFromFile(filepath.Join(home, ".claude.json")))
+	}
+	return provider, loggedIn, identity
+}
+
+// shallowCredentialPresent reports whether path holds a non-empty JSON
+// object: the shape every provider's credential file takes once a login has
+// happened, and what an empty placeholder written at creation lacks.
+func shallowCredentialPresent(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	var obj map[string]json.RawMessage
+	return json.Unmarshal(data, &obj) == nil && len(obj) > 0
 }
 
 type shallowListOutput struct {
@@ -376,6 +412,7 @@ func runShallowProfileList(cmd *cobra.Command, _ []string) error {
 		out := shallowListOutput{BaseDir: mgr.BaseDir(), Count: len(profiles)}
 		for _, p := range profiles {
 			item := shallowListItem{Name: p.Name, Path: p.Path}
+			item.Provider, item.LoggedIn, item.Identity = shallowLoginState(mgr, p.Name, p.Path)
 			if p.Meta != nil {
 				item.CredentialFrom = p.Meta.CredentialFrom
 				item.CreatedAt = p.Meta.CreatedAt
@@ -395,7 +432,7 @@ func runShallowProfileList(cmd *cobra.Command, _ []string) error {
 		return nil
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "Shallow profiles (base: %s)\n", mgr.BaseDir())
-	fmt.Fprintf(cmd.OutOrStdout(), "%-22s  %-32s  %s\n", "NAME", "CREDENTIALS", "CREATED")
+	fmt.Fprintf(cmd.OutOrStdout(), "%-22s  %-32s  %-24s  %s\n", "NAME", "LOGIN", "SOURCE", "CREATED")
 	for _, p := range profiles {
 		credFrom := "(none)"
 		created := "?"
@@ -407,7 +444,15 @@ func runShallowProfileList(cmd *cobra.Command, _ []string) error {
 				created = p.Meta.CreatedAt.Local().Format("2006-01-02 15:04")
 			}
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "%-22s  %-32s  %s\n", p.Name, credFrom, created)
+		_, loggedIn, identity := shallowLoginState(mgr, p.Name, p.Path)
+		login := "not logged in"
+		switch {
+		case identity != "":
+			login = identity
+		case loggedIn:
+			login = "logged in"
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "%-22s  %-32s  %-24s  %s\n", p.Name, login, credFrom, created)
 	}
 	return nil
 }
@@ -792,12 +837,7 @@ func shallowSpawnDoubleSpend(provider, profileHome string) (label string, confli
 	if shallow.NormalizeProvider(provider) != "claude" {
 		return "", false
 	}
-	cred, err := os.ReadFile(filepath.Join(profileHome, ".claude", ".credentials.json"))
-	if err != nil {
-		return "", false
-	}
-	var credObj map[string]json.RawMessage
-	if json.Unmarshal(cred, &credObj) != nil || len(credObj) == 0 {
+	if !shallowCredentialPresent(filepath.Join(profileHome, ".claude", ".credentials.json")) {
 		return "", false
 	}
 	profileKeys := authfile.ClaudeIdentityKeysFromFile(filepath.Join(profileHome, ".claude.json"))

--- a/cmd/caam/cmd/shallow.go
+++ b/cmd/caam/cmd/shallow.go
@@ -726,6 +726,7 @@ func runShallowSpawn(cmd *cobra.Command, args []string) error {
 	for _, k := range scrub {
 		delete(envMap, k)
 	}
+	envMap["PATH"] = prependShallowLocalBin(envMap["PATH"], prof.Path)
 	envSlice := make([]string, 0, len(envMap))
 	for k, v := range envMap {
 		envSlice = append(envSlice, k+"="+v)
@@ -805,6 +806,29 @@ func shallowSpawnDoubleSpend(provider, profileHome string) (label string, confli
 		return "", false
 	}
 	return authfile.ClaudeIdentityLabel(profileKeys), true
+}
+
+// prependShallowLocalBin puts <home>/.local/bin first on PATH when that
+// directory exists under the shallow HOME. It is a symlink to the real
+// ~/.local/bin, so nothing new becomes runnable; but tools that check
+// "$HOME/.local/bin is on PATH" as a literal string (Claude Code's system
+// diagnostics warn about its native install otherwise) see the path they
+// expect under the shallow HOME. A PATH that already lists it is returned
+// unchanged.
+func prependShallowLocalBin(path, home string) string {
+	bin := filepath.Join(home, ".local", "bin")
+	if st, err := os.Stat(bin); err != nil || !st.IsDir() {
+		return path
+	}
+	for _, p := range filepath.SplitList(path) {
+		if p == bin {
+			return path
+		}
+	}
+	if path == "" {
+		return bin
+	}
+	return bin + string(os.PathListSeparator) + path
 }
 
 // injectCodexEffort translates shallow-spawn's --effort flag into the config

--- a/cmd/caam/cmd/shallow.go
+++ b/cmd/caam/cmd/shallow.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/authfile"
 	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/shallow"
 	"github.com/spf13/cobra"
 )
@@ -63,10 +64,13 @@ Layout under ~/orch-homes/<name>/ (claude shown):
 
 Spawn under a shallow identity with:
 
-  caam shallow-spawn <name> -- <tool>
+  caam shallow-spawn <name>            # runs that profile's own provider CLI
+  caam shallow-spawn <name> -- <cmd>   # runs something else instead
 
 which sets HOME=~/orch-homes/<name> (plus CODEX_HOME/GEMINI_HOME for those
-providers) and execs the command.`,
+providers) and execs the command. shallow-spawn also creates the profile if it
+does not exist yet, so this command is only needed when you want a specific
+credential source (--from-vault / --from-file).`,
 }
 
 func init() {
@@ -236,7 +240,7 @@ func runShallowProfileCreate(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(cmd.OutOrStdout(), "  Credentials: %s\n", opts.CredentialFromLabel)
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "\nNext steps:\n")
-	fmt.Fprintf(cmd.OutOrStdout(), "  caam shallow-spawn %s -- %s\n", name, shallowSpawnHintBin(provider))
+	fmt.Fprintf(cmd.OutOrStdout(), "  caam shallow-spawn %s        # opens %s under this profile\n", name, shallowSpawnHintBin(provider))
 	return nil
 }
 
@@ -490,11 +494,32 @@ func runShallowProfileDelete(cmd *cobra.Command, args []string) error {
 
 // shallowSpawnCmd sets HOME=<orch-homes>/<name> and execs the requested command.
 var shallowSpawnCmd = &cobra.Command{
-	Use:   "shallow-spawn <name> -- <cmd> [args...]",
-	Short: "Run a command under a shallow profile's HOME",
-	Long: `Set HOME (and SHALLOW_PROFILE) to the named shallow profile and exec
-the given command. Concurrent invocations under different names hit
+	Use:   "shallow-spawn <name> [-- <cmd> [args...]]",
+	Short: "Open a shallow profile's provider CLI (or any command) under its HOME",
+	Long: `Set HOME (and SHALLOW_PROFILE) to the named shallow profile and exec a
+command under it. Concurrent invocations under different names hit
 independent .credentials.json files and can run truly in parallel.
+
+  caam shallow-spawn alice
+
+is the short form: with no '-- <cmd>' section it runs the profile's OWN
+provider CLI (claude for a claude profile, codex for codex, agy for agy), so
+"open Claude as alice in this terminal" is one command. Pass '-- <cmd>' to run
+anything else instead; explicit commands behave exactly as before.
+
+Create on first use: an unknown <name> is provisioned as an EMPTY shallow
+profile (layout from --tool, default claude) and the session starts right
+away, so the first run of a new identity is a login prompt rather than an
+error. Credentials are never copied from the vault here — two profiles sharing
+one refresh-token family invalidate each other (issue #19). Use
+'caam shallow-profile create <name> --from-vault <tool>/<profile>' when a vault
+copy really is what you want.
+
+Double-spend guard (claude only): if the profile is already logged in as the
+SAME account that is active in your real HOME, the spawn is refused, because
+both sessions would draw down one subscription's quota. Pass --force to
+override. The check is skipped when either side has no oauthAccount recorded,
+and for codex/agy, which keep no comparable account identity on disk.
 
 Each spawn also backfills missing symlinks for user-installed skills
 (~/.claude/skills, ~/.codex/skills, ~/.gemini/skills) into the shallow
@@ -502,14 +527,18 @@ profile, so spawned sessions see the same skill library as direct ones.
 Auth/config files stay real and private; nothing is copied or overwritten.
 
 Examples:
-  caam shallow-spawn alice -- claude
+  caam shallow-spawn alice                     # open Claude as alice (creating alice if new)
+  caam shallow-spawn cx --tool codex           # first use: codex layout, then open codex
   caam shallow-spawn alice -- claude --print "explain this codebase"
   caam shallow-spawn alice -- bash -c 'echo $HOME'
+  caam shallow-spawn alice --force             # open it even if alice is the live account
   caam shallow-spawn codex-bob --reload-daemon -- codex
   caam shallow-spawn codex-bob --effort xhigh -- codex --model gpt-5.6-sol
 
 Use 'caam shallow-spawn <name> --print-env' to print the environment that
-WOULD be applied without executing anything (useful for shell wrappers).
+WOULD be applied without executing anything (useful for shell wrappers). It is
+a strict dry run: it never creates a missing profile (an unknown name is an
+error there) and the double-spend guard does not apply to it.
 
 --reload-daemon (codex only) mirrors 'caam activate/next': after the on-disk
 auth swap it SIGTERMs any running codex app-server/mcp-server daemon so the
@@ -531,6 +560,8 @@ func init() {
 	shallowSpawnCmd.Flags().Bool("print-env", false, "print HOME=... assignments and exit (no exec)")
 	shallowSpawnCmd.Flags().Bool("reload-daemon", false, "for codex: SIGTERM a running codex app-server/mcp-server daemon so the switched auth takes effect (it respawns on next use)")
 	shallowSpawnCmd.Flags().String("effort", "", "for codex: model reasoning effort (e.g. minimal|low|medium|high|xhigh), injected as '-c model_reasoning_effort=<effort>' since codex has no --effort flag")
+	shallowSpawnCmd.Flags().String("tool", "claude", "provider layout to use when creating a profile that does not exist yet: claude, codex, or agy")
+	shallowSpawnCmd.Flags().Bool("force", false, "spawn even when this profile is the Claude account already active in your real HOME (double-spend guard override)")
 	shallowSpawnCmd.Flags().Bool("allow-agent-view", false, "for claude: keep Claude Code's Agent View / background supervisor enabled instead of injecting CLAUDE_CODE_DISABLE_AGENT_VIEW=1 (opts back into Agent View, accepting that its cross-session supervisor daemon can bypass per-identity auth isolation — see issue #49)")
 }
 
@@ -554,10 +585,18 @@ func runShallowSpawn(cmd *cobra.Command, args []string) error {
 
 	prof, err := mgr.Get(name)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("shallow profile %q does not exist (try `caam shallow-profile create %s`)", name, name)
+		if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("load shallow profile: %w", err)
 		}
-		return fmt.Errorf("load shallow profile: %w", err)
+		// Create on first use. --print-env is a strict dry run, so it reports
+		// the missing profile instead of provisioning one behind the user's
+		// back; a real spawn provisions and continues.
+		if printEnv {
+			return fmt.Errorf("shallow profile %q does not exist; --print-env is a dry run and never creates one — run `caam shallow-spawn %s` (add --tool codex|agy for a non-claude layout) to create it and start the session", name, name)
+		}
+		if prof, err = createShallowProfileForSpawn(cmd, mgr, name); err != nil {
+			return err
+		}
 	}
 
 	// Provider drives the env-isolation policy (which provider-home var to pin or
@@ -568,6 +607,15 @@ func runShallowSpawn(cmd *cobra.Command, args []string) error {
 	provider, err := mgr.ResolveProvider(name)
 	if err != nil {
 		return err
+	}
+	// --tool only chooses a layout for a profile we are creating. Naming an
+	// existing profile with a conflicting --tool is a mistake worth surfacing:
+	// silently ignoring it would look like the layout had been changed.
+	if cmd.Flags().Changed("tool") {
+		wanted, _ := cmd.Flags().GetString("tool")
+		if norm := shallow.NormalizeProvider(wanted); norm != shallow.NormalizeProvider(provider) {
+			return fmt.Errorf("--tool %q conflicts with existing shallow profile %q (provider: %s); --tool only applies when the profile is created on first use", wanted, name, provider)
+		}
 	}
 	// Agent View policy (#49): disable Claude Code's cross-session background
 	// supervisor for shallow claude sessions unless the user opted back in with
@@ -596,8 +644,24 @@ func runShallowSpawn(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// Default command: with no `-- <cmd>` section, run the profile's own
+	// provider CLI. This is the whole point of the short form — `caam
+	// shallow-spawn alice` means "open Claude as alice, here, now".
 	if len(rest) == 0 {
-		return fmt.Errorf("missing command after %q (use `caam shallow-spawn %s -- %s`)", name, name, shallowSpawnHintBin(provider))
+		rest = []string{shallowSpawnHintBin(provider)}
+	}
+
+	// Double-spend guard: refuse to open a claude profile that is already the
+	// live account, unless the user insists with --force.
+	force, _ := cmd.Flags().GetBool("force")
+	if !force {
+		if label, conflict := shallowSpawnDoubleSpend(provider, prof.Path); conflict {
+			who := name
+			if label != "" {
+				who = fmt.Sprintf("%s (%s)", name, label)
+			}
+			return fmt.Errorf("%q is the account already active in your real HOME (~/.claude.json); running it here too would spend the same quota twice. Run %q directly in this terminal, or pass --force", who, shallowSpawnHintBin(provider))
+		}
 	}
 
 	// Skill-share repair (#56): user-installed skills (e.g. ~/.codex/skills
@@ -670,6 +734,77 @@ func runShallowSpawn(cmd *cobra.Command, args []string) error {
 	// On Unix, exec the target so signals/exit propagate naturally and we
 	// don't add a stray caam process to the tree.
 	return spawnExec(binPath, rest, envSlice)
+}
+
+// createShallowProfileForSpawn provisions the EMPTY shallow profile that
+// shallow-spawn creates on first use, using the same shallow.Manager.Create
+// path as `caam shallow-profile create <name> --tool <tool>` with no credential
+// source — the profile's private credential file is left empty so the first
+// session logs in as the account the user actually wants there.
+//
+// It deliberately offers no --from-vault equivalent. Seeding a shallow profile
+// from a vault snapshot duplicates one refresh-token family across two homes,
+// and Claude rotates the refresh token on use, so whichever side refreshes
+// second is logged out (issue #19). Copying a credential must stay an explicit
+// `shallow-profile create --from-vault` decision, never an implicit side effect
+// of opening a terminal.
+func createShallowProfileForSpawn(cmd *cobra.Command, mgr *shallow.Manager, name string) (*shallow.Profile, error) {
+	tool, _ := cmd.Flags().GetString("tool")
+	provider := shallow.NormalizeProvider(tool)
+	if _, err := mgr.Create(name, shallow.CreateOptions{Provider: provider}); err != nil {
+		return nil, fmt.Errorf("create shallow profile %q on first use: %w", name, err)
+	}
+	fmt.Fprintf(cmd.ErrOrStderr(),
+		"created shallow profile %q (empty, provider: %s): the first run will ask you to log in as that account\n",
+		name, provider)
+	prof, err := mgr.Get(name)
+	if err != nil {
+		return nil, fmt.Errorf("load shallow profile %q after creating it: %w", name, err)
+	}
+	return prof, nil
+}
+
+// shallowSpawnDoubleSpend reports whether spawning the shallow profile rooted
+// at profileHome would run the SAME account that is already active in the real
+// HOME — two live sessions drawing down one subscription's quota. It returns
+// the profile's human-facing identity (email, else account uuid) alongside the
+// verdict so the refusal can name the account.
+//
+// Claude only: codex and agy keep no account identity next to their
+// credentials, so there is nothing to compare and we never invent one.
+//
+// A conflict requires BOTH of:
+//
+//  1. The profile is actually logged in — its private .credentials.json holds
+//     a non-empty JSON object. This matters because a newly created shallow
+//     profile seeds its .claude.json from the real HOME (that is where its
+//     onboarding state comes from), so identity alone would flag every
+//     brand-new profile as a double spend on its very first, login-only run.
+//  2. The profile's oauthAccount and the live ~/.claude.json's oauthAccount
+//     share an identity key — accountUuid, else emailAddress.
+//
+// Either side missing an oauthAccount yields no conflict: an unknown identity
+// is never evidence of a match. The live path is resolved through
+// authfile.ClaudeAuthFiles() so this agrees with every other caam command
+// about which file holds the live identity.
+func shallowSpawnDoubleSpend(provider, profileHome string) (label string, conflict bool) {
+	if shallow.NormalizeProvider(provider) != "claude" {
+		return "", false
+	}
+	cred, err := os.ReadFile(filepath.Join(profileHome, ".claude", ".credentials.json"))
+	if err != nil {
+		return "", false
+	}
+	var credObj map[string]json.RawMessage
+	if json.Unmarshal(cred, &credObj) != nil || len(credObj) == 0 {
+		return "", false
+	}
+	profileKeys := authfile.ClaudeIdentityKeysFromFile(filepath.Join(profileHome, ".claude.json"))
+	liveKeys := authfile.ClaudeLiveIdentityKeys(authfile.ClaudeAuthFiles())
+	if !authfile.IdentityKeysIntersect(profileKeys, liveKeys) {
+		return "", false
+	}
+	return authfile.ClaudeIdentityLabel(profileKeys), true
 }
 
 // injectCodexEffort translates shallow-spawn's --effort flag into the config

--- a/cmd/caam/cmd/shallow_test.go
+++ b/cmd/caam/cmd/shallow_test.go
@@ -1193,3 +1193,56 @@ func TestPrependShallowLocalBin(t *testing.T) {
 		t.Fatalf("empty PATH: got %q, want %q", got, bin)
 	}
 }
+
+// TestShallowList_ShowsLiveLoginState pins the LOGIN column: it reflects the
+// profile's credential file and identity right now, not the creation-time
+// source, which stays "(none)" for a profile that logged in later.
+func TestShallowList_ShowsLiveLoginState(t *testing.T) {
+	base, _ := shallowEnv(t)
+
+	for _, name := range []string{"fresh", "logged"} {
+		if _, _, err := runCmdCaptured(t, "shallow-profile", "create", name, "--tool", "claude"); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+	loggedHome := filepath.Join(base, "logged")
+	if err := os.WriteFile(filepath.Join(loggedHome, ".claude", ".credentials.json"), []byte(`{"claudeAiOauth":{"accessToken":"t","refreshToken":"r"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(loggedHome, ".claude.json"), []byte(`{"oauthAccount":{"accountUuid":"u-logged","emailAddress":"logged@example.com"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout, _, err := runCmdCaptured(t, "shallow-profile", "list")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if !strings.Contains(stdout, "LOGIN") || !strings.Contains(stdout, "logged@example.com") || !strings.Contains(stdout, "not logged in") {
+		t.Fatalf("table lacks live login state:\n%s", stdout)
+	}
+
+	stdout, _, err = runCmdCaptured(t, "shallow-profile", "list", "--json")
+	if err != nil {
+		t.Fatalf("list --json: %v", err)
+	}
+	var out struct {
+		Profiles []struct {
+			Name     string `json:"name"`
+			LoggedIn bool   `json:"logged_in"`
+			Identity string `json:"identity"`
+		} `json:"profiles"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &out); err != nil {
+		t.Fatalf("unmarshal %q: %v", stdout, err)
+	}
+	got := map[string][2]any{}
+	for _, p := range out.Profiles {
+		got[p.Name] = [2]any{p.LoggedIn, p.Identity}
+	}
+	if got["fresh"] != [2]any{false, ""} {
+		t.Fatalf("fresh: %v", got["fresh"])
+	}
+	if got["logged"] != [2]any{true, "logged@example.com"} {
+		t.Fatalf("logged: %v", got["logged"])
+	}
+}

--- a/cmd/caam/cmd/shallow_test.go
+++ b/cmd/caam/cmd/shallow_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -117,6 +118,8 @@ func newShallowTestRoot() *cobra.Command {
 	spawn.Flags().Bool("reload-daemon", false, "")
 	spawn.Flags().Bool("allow-agent-view", false, "")
 	spawn.Flags().String("effort", "", "")
+	spawn.Flags().String("tool", "claude", "")
+	spawn.Flags().Bool("force", false, "")
 
 	root.AddCommand(parent)
 	root.AddCommand(spawn)
@@ -757,5 +760,411 @@ func TestShallowCreateVaultWithoutSnapshotMergesOnboarding(t *testing.T) {
 	// The real HOME's {"x":1} content (from fakeShallowHome) must survive.
 	if string(m["x"]) != "1" {
 		t.Fatalf("real HOME state fields dropped; staged = %s", staged)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// shallow-spawn ergonomics: default command, create-on-first-use, double-spend.
+// -----------------------------------------------------------------------------
+
+// fakeToolBin puts no-op executables for the named tools on PATH so
+// exec.LookPath resolves them without ever running a real provider CLI.
+func fakeToolBin(t *testing.T, names ...string) string {
+	t.Helper()
+	binDir := t.TempDir()
+	for _, n := range names {
+		if err := os.WriteFile(filepath.Join(binDir, n), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatalf("write fake %s: %v", n, err)
+		}
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return binDir
+}
+
+// captureSpawn swaps in a recording spawnExec and returns a pointer to the argv
+// it saw (nil-length until a spawn happens).
+func captureSpawn(t *testing.T) *[]string {
+	t.Helper()
+	got := new([]string)
+	orig := spawnExec
+	spawnExec = func(_ string, args []string, _ []string) error { *got = args; return nil }
+	t.Cleanup(func() { spawnExec = orig })
+	return got
+}
+
+// writeClaudeIdentity writes a .claude.json carrying a specific oauthAccount.
+func writeClaudeIdentity(t *testing.T, path, uuid, email string) {
+	t.Helper()
+	body := fmt.Sprintf(`{"hasCompletedOnboarding":true,"oauthAccount":{"accountUuid":%q,"emailAddress":%q}}`, uuid, email)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// TestShallowSpawnDefaultsToProviderCLI: `caam shallow-spawn <name>` with no
+// `-- <cmd>` section execs the profile's OWN provider CLI, so "open Claude as
+// alice in this terminal" is one command with no wrapper script.
+func TestShallowSpawnDefaultsToProviderCLI(t *testing.T) {
+	base, realHome := shallowEnv(t)
+	fakeToolBin(t, "claude", "codex")
+
+	codexDir := filepath.Join(realHome, ".codex")
+	if err := os.MkdirAll(codexDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(codexDir, "auth.json"), []byte(`{"OPENAI_API_KEY":null}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := runCmdCaptured(t, "shallow-profile", "create", "alice", "--json"); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := runCmdCaptured(t, "shallow-profile", "create", "cx", "--tool", "codex",
+		"--from-file", filepath.Join(codexDir, "auth.json"), "--json"); err != nil {
+		t.Fatal(err)
+	}
+
+	origCheck := shallowCodexDaemonCheck
+	shallowCodexDaemonCheck = func(string, bool, string) codexDaemonWarning { return codexDaemonWarning{} }
+	t.Cleanup(func() { shallowCodexDaemonCheck = origCheck })
+
+	var envSeen []string
+	origExec := spawnExec
+	var argvSeen []string
+	spawnExec = func(_ string, args []string, env []string) error {
+		argvSeen, envSeen = args, env
+		return nil
+	}
+	t.Cleanup(func() { spawnExec = origExec })
+
+	if _, _, err := runCmdCaptured(t, "shallow-spawn", "alice"); err != nil {
+		t.Fatalf("spawn alice: %v", err)
+	}
+	if len(argvSeen) != 1 || argvSeen[0] != "claude" {
+		t.Fatalf("claude profile default argv = %v, want [claude]", argvSeen)
+	}
+	wantHome := "HOME=" + filepath.Join(base, "alice")
+	found := false
+	for _, e := range envSeen {
+		if e == wantHome {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("default spawn did not set %s", wantHome)
+	}
+
+	if _, _, err := runCmdCaptured(t, "shallow-spawn", "cx"); err != nil {
+		t.Fatalf("spawn cx: %v", err)
+	}
+	if len(argvSeen) != 1 || argvSeen[0] != "codex" {
+		t.Fatalf("codex profile default argv = %v, want [codex]", argvSeen)
+	}
+
+	// An explicit command still wins over the default.
+	if _, _, err := runCmdCaptured(t, "shallow-spawn", "alice", "--", "sh", "-c", "true"); err != nil {
+		t.Fatalf("explicit spawn: %v", err)
+	}
+	if len(argvSeen) != 3 || argvSeen[0] != "sh" {
+		t.Fatalf("explicit argv = %v, want sh -c true", argvSeen)
+	}
+}
+
+// TestShallowSpawnCreatesMissingProfile: naming a profile that does not exist
+// creates it as an EMPTY shallow profile and continues to spawn, so the first
+// run of a new identity is a login instead of an error.
+func TestShallowSpawnCreatesMissingProfile(t *testing.T) {
+	base, _ := shallowEnv(t)
+	fakeToolBin(t, "claude", "codex")
+	argv := captureSpawn(t)
+
+	_, stderr, err := runCmdCaptured(t, "shallow-spawn", "newbie")
+	if err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	if !strings.Contains(stderr, `created shallow profile "newbie" (empty)`) {
+		t.Fatalf("expected create notice on stderr, got %q", stderr)
+	}
+	if !strings.Contains(stderr, "log in") {
+		t.Fatalf("create notice should explain the first run logs in, got %q", stderr)
+	}
+	if len(*argv) != 1 || (*argv)[0] != "claude" {
+		t.Fatalf("argv after create-on-first-use = %v, want [claude]", *argv)
+	}
+	// The profile is a real, EMPTY claude shallow profile.
+	cred := filepath.Join(base, "newbie", ".claude", ".credentials.json")
+	body, err := os.ReadFile(cred)
+	if err != nil {
+		t.Fatalf("read new profile credentials: %v", err)
+	}
+	if strings.TrimSpace(string(body)) != "" {
+		t.Fatalf("first-use profile should have EMPTY credentials, got %q", body)
+	}
+
+	// A second spawn reuses the profile without re-announcing creation.
+	_, stderr2, err := runCmdCaptured(t, "shallow-spawn", "newbie")
+	if err != nil {
+		t.Fatalf("second spawn: %v", err)
+	}
+	if strings.Contains(stderr2, "created shallow profile") {
+		t.Fatalf("second spawn should not recreate, stderr=%q", stderr2)
+	}
+}
+
+// TestShallowSpawnCreatesMissingProfileWithTool: --tool picks the layout for a
+// create-on-first-use spawn.
+func TestShallowSpawnCreatesMissingProfileWithTool(t *testing.T) {
+	base, _ := shallowEnv(t)
+	fakeToolBin(t, "claude", "codex")
+	argv := captureSpawn(t)
+	origCheck := shallowCodexDaemonCheck
+	shallowCodexDaemonCheck = func(string, bool, string) codexDaemonWarning { return codexDaemonWarning{} }
+	t.Cleanup(func() { shallowCodexDaemonCheck = origCheck })
+
+	if _, _, err := runCmdCaptured(t, "shallow-spawn", "cxnew", "--tool", "codex"); err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	if len(*argv) != 1 || (*argv)[0] != "codex" {
+		t.Fatalf("argv = %v, want [codex]", *argv)
+	}
+	if _, err := os.Stat(filepath.Join(base, "cxnew", ".codex", "auth.json")); err != nil {
+		t.Fatalf("expected a codex layout: %v", err)
+	}
+}
+
+// TestShallowSpawnPrintEnvDoesNotCreate: --print-env is a dry run. It never
+// provisions a profile; a missing name is an error that names the fix.
+func TestShallowSpawnPrintEnvDoesNotCreate(t *testing.T) {
+	base, _ := shallowEnv(t)
+	_, _, err := runCmdCaptured(t, "shallow-spawn", "ghost", "--print-env")
+	if err == nil {
+		t.Fatal("expected --print-env on a missing profile to fail")
+	}
+	if !strings.Contains(err.Error(), "does not exist") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(base, "ghost")); !os.IsNotExist(statErr) {
+		t.Fatalf("--print-env must not create the profile (err=%v)", statErr)
+	}
+}
+
+// TestShallowSpawnDoubleSpendGuard covers the quota guard: refuse to open a
+// shallow claude profile that is the SAME account already active in the real
+// HOME, since both sessions would draw down one subscription.
+func TestShallowSpawnDoubleSpendGuard(t *testing.T) {
+	const uuid = "11111111-2222-3333-4444-555555555555"
+
+	// setupClaude builds a logged-in claude shallow profile "alice" whose
+	// identity is (profUUID, profEmail), with the live real HOME logged in as
+	// liveJSON (written verbatim; "" leaves the real HOME's default state).
+	setupClaude := func(t *testing.T, profUUID, profEmail, liveJSON string) (base string) {
+		t.Helper()
+		base, realHome := shallowEnv(t)
+		fakeToolBin(t, "claude")
+
+		credSrc := filepath.Join(t.TempDir(), "creds.json")
+		if err := os.WriteFile(credSrc, []byte(`{"claudeAiOauth":{"accessToken":"fake"}}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := runCmdCaptured(t, "shallow-profile", "create", "alice",
+			"--from-file", credSrc, "--json"); err != nil {
+			t.Fatal(err)
+		}
+		writeClaudeIdentity(t, filepath.Join(base, "alice", ".claude.json"), profUUID, profEmail)
+		if liveJSON == "" {
+			writeClaudeIdentity(t, filepath.Join(realHome, ".claude.json"), uuid, "me@example.com")
+		} else if err := os.WriteFile(filepath.Join(realHome, ".claude.json"), []byte(liveJSON), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return base
+	}
+
+	t.Run("refuses when the account is already live", func(t *testing.T) {
+		setupClaude(t, uuid, "me@example.com", "")
+		argv := captureSpawn(t)
+		_, _, err := runCmdCaptured(t, "shallow-spawn", "alice")
+		if err == nil {
+			t.Fatal("expected the double-spend guard to refuse")
+		}
+		if !strings.Contains(err.Error(), "same quota twice") || !strings.Contains(err.Error(), "--force") {
+			t.Fatalf("unhelpful guard error: %v", err)
+		}
+		if len(*argv) != 0 {
+			t.Fatalf("guard must block the exec, but argv=%v", *argv)
+		}
+	})
+
+	t.Run("matches on email when the uuid is absent", func(t *testing.T) {
+		base, realHome := shallowEnv(t)
+		fakeToolBin(t, "claude")
+		credSrc := filepath.Join(t.TempDir(), "creds.json")
+		if err := os.WriteFile(credSrc, []byte(`{"claudeAiOauth":{"accessToken":"fake"}}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := runCmdCaptured(t, "shallow-profile", "create", "alice",
+			"--from-file", credSrc, "--json"); err != nil {
+			t.Fatal(err)
+		}
+		writeClaudeIdentity(t, filepath.Join(base, "alice", ".claude.json"), "", "me@example.com")
+		writeClaudeIdentity(t, filepath.Join(realHome, ".claude.json"), uuid, "me@example.com")
+		captureSpawn(t)
+		if _, _, err := runCmdCaptured(t, "shallow-spawn", "alice"); err == nil {
+			t.Fatal("expected an email match to refuse")
+		}
+	})
+
+	t.Run("--force overrides", func(t *testing.T) {
+		setupClaude(t, uuid, "me@example.com", "")
+		argv := captureSpawn(t)
+		if _, _, err := runCmdCaptured(t, "shallow-spawn", "alice", "--force"); err != nil {
+			t.Fatalf("--force should override the guard: %v", err)
+		}
+		if len(*argv) != 1 || (*argv)[0] != "claude" {
+			t.Fatalf("argv = %v, want [claude]", *argv)
+		}
+	})
+
+	t.Run("allows a different account", func(t *testing.T) {
+		setupClaude(t, "99999999-8888-7777-6666-555555555555", "other@example.com", "")
+		argv := captureSpawn(t)
+		if _, _, err := runCmdCaptured(t, "shallow-spawn", "alice"); err != nil {
+			t.Fatalf("a different account must spawn: %v", err)
+		}
+		if len(*argv) != 1 {
+			t.Fatalf("argv = %v", *argv)
+		}
+	})
+
+	t.Run("skips when the live HOME has no oauthAccount", func(t *testing.T) {
+		setupClaude(t, uuid, "me@example.com", `{"hasCompletedOnboarding":true}`)
+		argv := captureSpawn(t)
+		if _, _, err := runCmdCaptured(t, "shallow-spawn", "alice"); err != nil {
+			t.Fatalf("no live identity means no guard: %v", err)
+		}
+		if len(*argv) != 1 {
+			t.Fatalf("argv = %v", *argv)
+		}
+	})
+
+	t.Run("skips when the profile has no oauthAccount", func(t *testing.T) {
+		base := setupClaude(t, uuid, "me@example.com", "")
+		if err := os.WriteFile(filepath.Join(base, "alice", ".claude.json"), []byte(`{"x":1}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		argv := captureSpawn(t)
+		if _, _, err := runCmdCaptured(t, "shallow-spawn", "alice"); err != nil {
+			t.Fatalf("no profile identity means no guard: %v", err)
+		}
+		if len(*argv) != 1 {
+			t.Fatalf("argv = %v", *argv)
+		}
+	})
+
+	// A profile that has never been logged in inherits the real HOME's
+	// .claude.json (that is where its onboarding state comes from), so identity
+	// alone would false-positive. An empty credential file means "not logged in
+	// here yet" and must never be refused.
+	t.Run("skips a profile that is not logged in yet", func(t *testing.T) {
+		base, realHome := shallowEnv(t)
+		fakeToolBin(t, "claude")
+		writeClaudeIdentity(t, filepath.Join(realHome, ".claude.json"), uuid, "me@example.com")
+		if _, _, err := runCmdCaptured(t, "shallow-profile", "create", "fresh", "--json"); err != nil {
+			t.Fatal(err)
+		}
+		// create copies the real HOME state, so the identities DO match.
+		staged, err := os.ReadFile(filepath.Join(base, "fresh", ".claude.json"))
+		if err != nil || !strings.Contains(string(staged), uuid) {
+			t.Fatalf("precondition: expected the seeded state to carry the live uuid, got %q err=%v", staged, err)
+		}
+		argv := captureSpawn(t)
+		if _, _, err := runCmdCaptured(t, "shallow-spawn", "fresh"); err != nil {
+			t.Fatalf("an empty profile must still spawn (it needs to log in): %v", err)
+		}
+		if len(*argv) != 1 {
+			t.Fatalf("argv = %v", *argv)
+		}
+	})
+
+	t.Run("skips non-claude providers", func(t *testing.T) {
+		_, realHome := shallowEnv(t)
+		fakeToolBin(t, "codex")
+		writeClaudeIdentity(t, filepath.Join(realHome, ".claude.json"), uuid, "me@example.com")
+		codexDir := filepath.Join(realHome, ".codex")
+		if err := os.MkdirAll(codexDir, 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(codexDir, "auth.json"), []byte(`{"OPENAI_API_KEY":null}`), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if _, _, err := runCmdCaptured(t, "shallow-profile", "create", "cx", "--tool", "codex",
+			"--from-file", filepath.Join(codexDir, "auth.json"), "--json"); err != nil {
+			t.Fatal(err)
+		}
+		origCheck := shallowCodexDaemonCheck
+		shallowCodexDaemonCheck = func(string, bool, string) codexDaemonWarning { return codexDaemonWarning{} }
+		t.Cleanup(func() { shallowCodexDaemonCheck = origCheck })
+		argv := captureSpawn(t)
+		if _, _, err := runCmdCaptured(t, "shallow-spawn", "cx"); err != nil {
+			t.Fatalf("codex has no identity file to compare: %v", err)
+		}
+		if len(*argv) != 1 {
+			t.Fatalf("argv = %v", *argv)
+		}
+	})
+
+	// --print-env is a dry run that spends nothing, so the guard never fires.
+	t.Run("does not block --print-env", func(t *testing.T) {
+		setupClaude(t, uuid, "me@example.com", "")
+		stdout, _, err := runCmdCaptured(t, "shallow-spawn", "alice", "--print-env")
+		if err != nil {
+			t.Fatalf("--print-env must not be guarded: %v", err)
+		}
+		if !strings.Contains(stdout, "HOME=") {
+			t.Fatalf("unexpected --print-env output %q", stdout)
+		}
+	})
+}
+
+// TestShallowSpawnHelpDocumentsErgonomics keeps the help text honest about the
+// three ergonomics rules a user has to know before typing the short form.
+func TestShallowSpawnHelpDocumentsErgonomics(t *testing.T) {
+	help := shallowSpawnCmd.Long + "\n" + shallowSpawnCmd.Use + "\n" + shallowSpawnCmd.Short
+	for _, want := range []string{
+		"caam shallow-spawn alice",
+		"--tool",
+		"--force",
+		"--print-env",
+	} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("shallow-spawn help does not mention %q", want)
+		}
+	}
+	if !strings.Contains(help, "created") && !strings.Contains(help, "create") {
+		t.Fatal("shallow-spawn help does not mention create-on-first-use")
+	}
+}
+
+// TestShallowSpawnToolConflictsWithExistingProfile: --tool only chooses a
+// layout for a profile being created, so naming an existing profile with a
+// different provider must fail loudly instead of looking like a conversion.
+func TestShallowSpawnToolConflictsWithExistingProfile(t *testing.T) {
+	_, _ = shallowEnv(t)
+	fakeToolBin(t, "claude", "codex")
+	if _, _, err := runCmdCaptured(t, "shallow-profile", "create", "alice", "--json"); err != nil {
+		t.Fatal(err)
+	}
+	argv := captureSpawn(t)
+	_, _, err := runCmdCaptured(t, "shallow-spawn", "alice", "--tool", "codex")
+	if err == nil {
+		t.Fatal("expected --tool on an existing claude profile to fail")
+	}
+	if !strings.Contains(err.Error(), "conflicts with existing shallow profile") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(*argv) != 0 {
+		t.Fatalf("conflict must block the exec, argv=%v", *argv)
+	}
+	// The matching --tool is accepted.
+	if _, _, err := runCmdCaptured(t, "shallow-spawn", "alice", "--tool", "claude"); err != nil {
+		t.Fatalf("matching --tool must be accepted: %v", err)
 	}
 }

--- a/cmd/caam/cmd/shallow_test.go
+++ b/cmd/caam/cmd/shallow_test.go
@@ -1168,3 +1168,28 @@ func TestShallowSpawnToolConflictsWithExistingProfile(t *testing.T) {
 		t.Fatalf("matching --tool must be accepted: %v", err)
 	}
 }
+
+// TestPrependShallowLocalBin covers the PATH adjustment that keeps Claude
+// Code's "~/.local/bin is not in your PATH" diagnostic quiet under a shallow
+// HOME whose .local/bin is a symlink to the real one.
+func TestPrependShallowLocalBin(t *testing.T) {
+	home := t.TempDir()
+	bin := filepath.Join(home, ".local", "bin")
+	sep := string(os.PathListSeparator)
+
+	if got := prependShallowLocalBin("/usr/bin", home); got != "/usr/bin" {
+		t.Fatalf("missing .local/bin: PATH changed to %q", got)
+	}
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := prependShallowLocalBin("/usr/bin", home), bin+sep+"/usr/bin"; got != want {
+		t.Fatalf("prepend: got %q, want %q", got, want)
+	}
+	if got, want := prependShallowLocalBin(bin+sep+"/usr/bin", home), bin+sep+"/usr/bin"; got != want {
+		t.Fatalf("already present: got %q, want %q", got, want)
+	}
+	if got := prependShallowLocalBin("", home); got != bin {
+		t.Fatalf("empty PATH: got %q, want %q", got, bin)
+	}
+}

--- a/internal/authfile/authfile.go
+++ b/internal/authfile/authfile.go
@@ -516,8 +516,8 @@ func (v *Vault) Backup(fileSet AuthFileSet, profile string) error {
 	// unparseable later (issue #73). Claude only: the other tools carry their
 	// identity inside the credential file itself.
 	if tool == "claude" {
-		if keys := claudeLiveIdentityKeys(fileSet); len(keys) > 0 {
-			meta.Identity = claudeIdentityLabel(keys)
+		if keys := ClaudeLiveIdentityKeys(fileSet); len(keys) > 0 {
+			meta.Identity = ClaudeIdentityLabel(keys)
 			meta.IdentityKeys = keys
 		}
 	}
@@ -792,7 +792,7 @@ func (v *Vault) Restore(fileSet AuthFileSet, profile string) error {
 	// copied over the live ~/.claude.json (issue #73).
 	var liveClaudeKeys []string
 	if fileSet.Tool == "claude" {
-		liveClaudeKeys = claudeLiveIdentityKeys(fileSet)
+		liveClaudeKeys = ClaudeLiveIdentityKeys(fileSet)
 	}
 
 	restored := 0
@@ -2193,9 +2193,9 @@ func claudeIdentityKeys(root map[string]interface{}) []string {
 	return keys
 }
 
-// claudeIdentityKeysFromFile parses a .claude.json at path and derives its
+// ClaudeIdentityKeysFromFile parses a .claude.json at path and derives its
 // identity keys. Unreadable or unparseable files yield nil.
-func claudeIdentityKeysFromFile(path string) []string {
+func ClaudeIdentityKeysFromFile(path string) []string {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil
@@ -2207,9 +2207,9 @@ func claudeIdentityKeysFromFile(path string) []string {
 	return claudeIdentityKeys(root)
 }
 
-// claudeIdentityLabel picks the human-facing identity out of a key set:
+// ClaudeIdentityLabel picks the human-facing identity out of a key set:
 // email, else account uuid, else the legacy account string.
-func claudeIdentityLabel(keys []string) string {
+func ClaudeIdentityLabel(keys []string) string {
 	for _, prefix := range []string{"email:", "uuid:", "account:"} {
 		for _, key := range keys {
 			if strings.HasPrefix(key, prefix) {
@@ -2220,8 +2220,8 @@ func claudeIdentityLabel(keys []string) string {
 	return ""
 }
 
-// identityKeysIntersect reports whether two key sets share any key.
-func identityKeysIntersect(a, b []string) bool {
+// IdentityKeysIntersect reports whether two key sets share any key.
+func IdentityKeysIntersect(a, b []string) bool {
 	if len(a) == 0 || len(b) == 0 {
 		return false
 	}
@@ -2263,21 +2263,22 @@ func claudeFileSetPath(fileSet AuthFileSet, name string) string {
 	return ""
 }
 
-// claudeLiveIdentityKeys derives the identity of the currently logged-in
-// Claude account from the live ~/.claude.json.
-func claudeLiveIdentityKeys(fileSet AuthFileSet) []string {
+// ClaudeLiveIdentityKeys derives the identity of the currently logged-in
+// Claude account from the live ~/.claude.json named by fileSet (pass
+// ClaudeAuthFiles() to resolve it the way every other caam command does).
+func ClaudeLiveIdentityKeys(fileSet AuthFileSet) []string {
 	settingsPath := claudeFileSetPath(fileSet, claudeSettingsFile)
 	if settingsPath == "" {
 		return nil
 	}
-	return claudeIdentityKeysFromFile(settingsPath)
+	return ClaudeIdentityKeysFromFile(settingsPath)
 }
 
 // claudeProfileIdentityKeys derives a vault profile's identity from its
 // .claude.json snapshot, merged with whatever Backup recorded in meta.json so
 // matching survives a missing or unparseable snapshot.
 func (v *Vault) claudeProfileIdentityKeys(profileDir string) []string {
-	keys := claudeIdentityKeysFromFile(filepath.Join(profileDir, claudeSettingsFile))
+	keys := ClaudeIdentityKeysFromFile(filepath.Join(profileDir, claudeSettingsFile))
 	if metaKeys := profileMetaIdentityKeys(profileDir); len(metaKeys) > 0 {
 		keys = mergeIdentityKeys(keys, metaKeys)
 	}
@@ -2306,7 +2307,7 @@ func profileMetaIdentityKeys(profileDir string) []string {
 // active one. User-named profiles win over system profiles (_backup_* etc.),
 // which can legitimately carry the same account.
 func (v *Vault) claudeActiveProfileByIdentity(fileSet AuthFileSet, profiles []string) string {
-	liveKeys := claudeLiveIdentityKeys(fileSet)
+	liveKeys := ClaudeLiveIdentityKeys(fileSet)
 	if len(liveKeys) == 0 {
 		return ""
 	}
@@ -2314,7 +2315,7 @@ func (v *Vault) claudeActiveProfileByIdentity(fileSet AuthFileSet, profiles []st
 	systemMatch := ""
 	for _, profile := range profiles {
 		profileKeys := v.claudeProfileIdentityKeys(v.ProfilePath(fileSet.Tool, profile))
-		if !identityKeysIntersect(liveKeys, profileKeys) {
+		if !IdentityKeysIntersect(liveKeys, profileKeys) {
 			continue
 		}
 		if !IsSystemProfile(profile) {
@@ -2400,7 +2401,7 @@ func (v *Vault) claudeLiveIsNewer(liveKeys []string, profileDir, livePath, snaps
 	}
 
 	// Only guard when it is unambiguously the SAME account.
-	if !identityKeysIntersect(liveKeys, v.claudeProfileIdentityKeys(profileDir)) {
+	if !IdentityKeysIntersect(liveKeys, v.claudeProfileIdentityKeys(profileDir)) {
 		return false
 	}
 
@@ -2422,7 +2423,7 @@ func (v *Vault) claudeLiveIsNewer(liveKeys []string, profileDir, livePath, snaps
 // (email when known), falling back to JWT claims in .credentials.json for
 // legacy token formats.
 func (v *Vault) claudeProfileIdentity(profileDir string) string {
-	if label := claudeIdentityLabel(v.claudeProfileIdentityKeys(profileDir)); label != "" {
+	if label := ClaudeIdentityLabel(v.claudeProfileIdentityKeys(profileDir)); label != "" {
 		return label
 	}
 


### PR DESCRIPTION
## Problem

Shallow profiles already give one machine N concurrent identities, but `caam shallow-spawn` could not express the thing people reach for, which is "open Claude on account X, in this terminal, right now." It required the profile to exist already and an explicit command after `--`, so the ergonomics ended up in per-user shell wrappers instead of in caam.

## Three backward-compatible changes to `shallow-spawn`

1. **Default command.** `caam shallow-spawn alice` with no `-- <cmd>` runs the profile's own provider CLI (`claude` / `codex` / `agy`), resolved through the same `ResolveProvider` that drives env isolation. Explicit commands behave exactly as before.
2. **Create on first use.** An unknown name is provisioned as an *empty* shallow profile (layout from a new `--tool`, default `claude`) through the same `shallow.Manager.Create` path as `shallow-profile create`, a one-line notice goes to stderr, and the session starts, so the first run of a new identity is a login prompt rather than an error. Credentials are deliberately never copied from the vault here: two homes sharing one refresh-token family invalidate each other (#19). Seeding from the vault stays an explicit `shallow-profile create --from-vault` decision. `--tool` on an existing profile of a different provider is an error rather than a silent no-op.
3. **Double-spend guard (claude only).** If the profile is already logged in as the same account that is active in the real HOME, the spawn is refused with an explanation, since both sessions would draw down one subscription's quota. `--force` overrides. "Logged in" means the profile's private `.credentials.json` holds a non-empty object; that matters because a fresh empty profile seeds its `.claude.json` from the real HOME, so identity alone would flag every new profile on its login run. Either side lacking an `oauthAccount` yields no conflict. Identity comparison reuses the existing `authfile` identity-key helpers (exported in a small refactor commit, no behavior change).

`--print-env` stays a strict dry run: it never creates a profile and the guard does not apply. An unknown name errors with the command that would create it.

## Docs

README shallow-profiles section: a "Daily flow" (`caam shallow-spawn <name>` for a second account in this terminal, `caam next <tool>` for the main lane) and the double-spend rule. SKILL.md / references updated for parity (#62).

## Tests

`cmd/caam/cmd/shallow_test.go`, written red first: default command per layout; missing profile created empty and spawn proceeds; `--tool codex` creates a codex layout; conflicting `--tool` on an existing profile errors; guard refuses on matching uuid, allows with `--force`, skips when either side lacks `oauthAccount`, skips for codex, skips for a not-yet-logged-in profile; `--print-env` on a missing profile errors and creates nothing. All paths via `t.TempDir()`.

Gate: `gofmt -l`, `go vet ./...`, `go build ./cmd/caam`, `go test ./...` under an isolated HOME.

https://claude.ai/code/session_01UjcKgW7xJGKyA2FH4ypx75
