### PR TITLE
fix(claude): read and write the macOS login keychain (resolves #98)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ authorize app → wait for redirect → back to terminal
 
 ## The Solution
 
-Each AI CLI stores OAuth tokens in plain files. `caam` backs them up and restores them:
+Each AI CLI stores OAuth tokens in plain files — except Claude Code on macOS, which keeps them in the login keychain. `caam` backs up both and restores them:
 
 ```bash
 caam activate claude bob@gmail.com   # ~50ms, done
@@ -264,13 +264,24 @@ wait
 **Subscription:** Claude Max ($200/month)
 
 **Auth Files:**
-- `~/.claude/.credentials.json` — Claude Code OAuth credentials (primary)
+- macOS login keychain, generic password `Claude Code-credentials` — where Claude Code actually keeps the OAuth tokens on a Mac
+- `~/.claude/.credentials.json` — Claude Code OAuth credentials (primary on Linux; on macOS, caam's mirror of the keychain item)
 - `~/.claude.json` — Session/account state
 - `~/.config/claude-code/auth.json` — Secondary auth data
 - `~/.claude/settings.json` — API key mode via `apiKeyHelper`
 - `~/Library/Application Support/Claude/config.json` — macOS: Claude Desktop's encrypted OAuth token cache (only its `oauth:tokenCache*` fields are tracked, so recent Claude Code builds can't reassert the previous account after a switch)
 
 **Login Command:** Inside Claude Code, type `/login`
+
+**macOS keychain:** Claude Code does not write `~/.claude/.credentials.json` on macOS. It stores the OAuth tokens as a generic password in the login keychain under the service `Claude Code-credentials`, with your login name as the account, and only falls back to the file when the keychain is unreachable. caam reads and writes that item through `/usr/bin/security`, the same way Claude Code does:
+
+- `caam backup` copies the keychain item into the vault profile, so the snapshot holds real tokens
+- `caam activate` writes the profile's tokens back into the keychain, which is what makes the switch visible to the CLI
+- every read path (`status`, `doctor`, profile detection, expiry checks) mirrors the keychain into `~/.claude/.credentials.json` first, so a Mac login is no longer invisible to caam
+
+The keychain stays authoritative: Claude Code rotates tokens there, and caam rewrites the mirror whenever the two differ. The mirror is a plaintext file with mode `0600`, the same format and permissions caam relies on everywhere else. `caam doctor` reports the keychain item under `claude keychain`. Set `CAAM_KEYCHAIN=0` to switch the bridge off.
+
+The keychain is scoped to `$HOME`. A shallow or isolated profile runs Claude Code with its own `HOME`, finds no keychain item there, and falls back to that profile's `.credentials.json` — which those modes seed from a vault profile. On macOS those snapshots held no credentials before this bridge existed, so the fix is what makes concurrent multi-account Claude sessions possible on a Mac. Plain `caam activate` swaps the one shared keychain item, so outside those modes a single account is live at a time.
 
 **Notes:** Claude Max has a 5-hour rolling usage window. When you hit it, you'll see rate limit messages. Switch accounts to continue.
 

--- a/cmd/caam/cmd/doctor.go
+++ b/cmd/caam/cmd/doctor.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/authfile"
 	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/config"
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/keychain"
 	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/profile"
 	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/provider"
 	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/provider/claude"
@@ -902,6 +903,37 @@ func checkLocks(fix bool) []CheckResult {
 	return results
 }
 
+// checkClaudeKeychain reports the state of the macOS login keychain item
+// Claude Code stores its OAuth tokens in. It returns nil off macOS, where
+// there is no keychain and the credentials file is the only source.
+func checkClaudeKeychain() *CheckResult {
+	if runtime.GOOS != "darwin" {
+		return nil
+	}
+	name := "claude keychain"
+	if !keychain.Available() {
+		return &CheckResult{
+			Name:    name,
+			Status:  "warn",
+			Message: "keychain unreachable",
+			Details: "caam cannot read " + keychain.ClaudeService + "; account switching will fall back to ~/.claude/.credentials.json, which Claude Code ignores on macOS",
+		}
+	}
+	if _, ok := keychain.ClaudeCredentials(); !ok {
+		return &CheckResult{
+			Name:    name,
+			Status:  "warn",
+			Message: "no Claude credentials in the login keychain",
+			Details: "run /login inside claude, then 'caam backup claude <name>' to capture the account",
+		}
+	}
+	return &CheckResult{
+		Name:    name,
+		Status:  "pass",
+		Message: "credentials in the login keychain (" + keychain.ClaudeService + "), mirrored for caam",
+	}
+}
+
 func checkAuthFiles() []CheckResult {
 	var results []CheckResult
 
@@ -913,6 +945,10 @@ func checkAuthFiles() []CheckResult {
 			Message: "vault not initialized",
 		})
 		return results
+	}
+
+	if kc := checkClaudeKeychain(); kc != nil {
+		results = append(results, *kc)
 	}
 
 	for tool, getFileSet := range tools {

--- a/internal/authfile/authfile.go
+++ b/internal/authfile/authfile.go
@@ -403,6 +403,10 @@ func (v *Vault) BackupPath(tool, profile, filename string) string {
 
 // Backup saves the current auth files to the vault.
 func (v *Vault) Backup(fileSet AuthFileSet, profile string) error {
+	// macOS keeps Claude's tokens in the keychain; mirror them into the
+	// credentials file first or the snapshot captures no credentials at all.
+	syncClaudeKeychainIn(fileSet)
+
 	profileDir, err := v.safeProfileDir(fileSet.Tool, profile)
 	if err != nil {
 		return err
@@ -770,6 +774,10 @@ func MigrateGeminiVaultDir(dir string) error {
 
 // Restore copies backed-up auth files to their original locations.
 func (v *Vault) Restore(fileSet AuthFileSet, profile string) error {
+	// The freshness guards below compare the snapshot against live state, so
+	// the live credentials file has to reflect the keychain before they run.
+	syncClaudeKeychainIn(fileSet)
+
 	profileDir, err := v.safeProfileDir(fileSet.Tool, profile)
 	if err != nil {
 		return err
@@ -905,6 +913,13 @@ func (v *Vault) Restore(fileSet AuthFileSet, profile string) error {
 		if !(fileSet.AllowOptionalOnly && !requiredFound && optionalFound) {
 			return fmt.Errorf("required backup not found: %s", missingRequired[0])
 		}
+	}
+
+	// On macOS the restored file is inert until it reaches the keychain, which
+	// is where Claude Code reads from. Fail loudly: a swallowed error here
+	// leaves the previous account live while caam reports a successful switch.
+	if err := syncClaudeKeychainOut(fileSet); err != nil {
+		return err
 	}
 
 	return nil
@@ -1059,6 +1074,8 @@ func (v *Vault) CopyProfile(tool, srcProfile, dstProfile string) error {
 // hashed so that volatile metadata (e.g., changelogLastFetched, numStartups)
 // does not break profile detection.
 func (v *Vault) ActiveProfile(fileSet AuthFileSet) (string, error) {
+	syncClaudeKeychainIn(fileSet)
+
 	profiles, err := v.List(fileSet.Tool)
 	if err != nil {
 		return "", err
@@ -1155,6 +1172,8 @@ func (v *Vault) ActiveProfile(fileSet AuthFileSet) (string, error) {
 
 // HasAuthFiles checks if the tool currently has auth files present.
 func HasAuthFiles(fileSet AuthFileSet) bool {
+	syncClaudeKeychainIn(fileSet)
+
 	optionalFound := false
 	for _, spec := range fileSet.Files {
 		// The Claude Desktop config only counts as auth when it holds a token
@@ -1193,7 +1212,7 @@ func ClearAuthFiles(fileSet AuthFileSet) error {
 			return fmt.Errorf("remove %s: %w", spec.Path, err)
 		}
 	}
-	return nil
+	return clearClaudeKeychain(fileSet)
 }
 
 // --- Claude Desktop OAuth token cache (macOS) -------------------------------

--- a/internal/authfile/keychain.go
+++ b/internal/authfile/keychain.go
@@ -1,0 +1,59 @@
+package authfile
+
+import (
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/keychain"
+)
+
+// --- macOS Keychain bridge for Claude Code ----------------------------------
+//
+// On macOS, Claude Code keeps its OAuth tokens in the login keychain
+// ("Claude Code-credentials"), not in ~/.claude/.credentials.json. Without a
+// bridge, every file-shaped operation in this package degrades on a Mac:
+// Backup writes a vault profile with no credentials, ActiveProfile cannot tell
+// two accounts apart, HasAuthFiles reads as logged out, and Restore swaps
+// dotfiles the CLI ignores while the keychain re-asserts the previous account.
+//
+// The bridge keeps the keychain authoritative and the file a mirror of it:
+//   - before reading live state, copy keychain -> ~/.claude/.credentials.json
+//   - after restoring a profile, copy ~/.claude/.credentials.json -> keychain
+//   - on clear, delete both
+//
+// Every helper is a no-op on platforms without a keychain, so the callers stay
+// platform-neutral. See internal/keychain.
+
+// claudeCredentialsLivePath returns the live credentials path in a Claude
+// file set, or "" for any other tool.
+func claudeCredentialsLivePath(fileSet AuthFileSet) string {
+	if fileSet.Tool != "claude" {
+		return ""
+	}
+	return claudeFileSetPath(fileSet, claudeCredentialsFile)
+}
+
+// syncClaudeKeychainIn refreshes the live credentials file from the keychain
+// so the rest of this package sees the tokens Claude Code is actually using.
+// Best-effort: a locked or empty keychain leaves whatever is on disk.
+func syncClaudeKeychainIn(fileSet AuthFileSet) {
+	if path := claudeCredentialsLivePath(fileSet); path != "" {
+		keychain.MirrorClaudeCredentials(path)
+	}
+}
+
+// syncClaudeKeychainOut pushes the restored credentials file into the
+// keychain. This is the step that makes `caam activate` take effect on macOS.
+func syncClaudeKeychainOut(fileSet AuthFileSet) error {
+	path := claudeCredentialsLivePath(fileSet)
+	if path == "" {
+		return nil
+	}
+	return keychain.StoreClaudeCredentials(path)
+}
+
+// clearClaudeKeychain removes the keychain item during logout, so the CLI does
+// not re-authenticate as the account whose file was just deleted.
+func clearClaudeKeychain(fileSet AuthFileSet) error {
+	if claudeCredentialsLivePath(fileSet) == "" {
+		return nil
+	}
+	return keychain.ClearClaudeCredentials()
+}

--- a/internal/authfile/keychain_test.go
+++ b/internal/authfile/keychain_test.go
@@ -1,0 +1,152 @@
+package authfile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/keychain"
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// claudeKeychainHome prepares a temp HOME with a deterministic Claude file set
+// and a fake keychain, the shape of a Mac where the CLI has logged in but left
+// nothing on disk.
+func claudeKeychainHome(t *testing.T) (home string, fs AuthFileSet) {
+	t.Helper()
+	testutil.FakeKeychain(t)
+
+	home = t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_CONFIG_DIR", filepath.Join(home, ".config", "claude-code"))
+	return home, ClaudeAuthFiles()
+}
+
+func seedKeychainLogin(t *testing.T, home, token, email string) string {
+	t.Helper()
+	blob := `{"claudeAiOauth":{"accessToken":"` + token + `","refreshToken":"r-` + token + `"}}`
+	testutil.SetKeychainItem(t, keychain.ClaudeService, keychain.CurrentAccount(), blob)
+
+	settings := `{"oauthAccount":{"accountUuid":"uuid-` + token + `","emailAddress":"` + email + `"}}`
+	if err := os.WriteFile(filepath.Join(home, ".claude.json"), []byte(settings), 0600); err != nil {
+		t.Fatalf("write .claude.json: %v", err)
+	}
+	return blob
+}
+
+// TestHasAuthFilesSeesKeychainOnlyLogin covers the macOS case where the only
+// evidence of a login is the keychain item: caam used to report "logged out"
+// and refuse to back the account up.
+func TestHasAuthFilesSeesKeychainOnlyLogin(t *testing.T) {
+	home, fs := claudeKeychainHome(t)
+
+	if HasAuthFiles(fs) {
+		t.Fatal("HasAuthFiles = true before any login")
+	}
+
+	seedKeychainLogin(t, home, "A", "alice@example.com")
+
+	if !HasAuthFiles(fs) {
+		t.Fatal("HasAuthFiles = false with credentials in the keychain")
+	}
+}
+
+// TestBackupCapturesKeychainCredentials proves the snapshot is no longer empty
+// on a Mac: the vault profile gets a real .credentials.json.
+func TestBackupCapturesKeychainCredentials(t *testing.T) {
+	home, fs := claudeKeychainHome(t)
+	blob := seedKeychainLogin(t, home, "A", "alice@example.com")
+
+	vault := NewVault(filepath.Join(t.TempDir(), "vault"))
+	if err := vault.Backup(fs, "alice"); err != nil {
+		t.Fatalf("backup: %v", err)
+	}
+
+	snapshot := filepath.Join(vault.ProfilePath("claude", "alice"), ".credentials.json")
+	data, err := os.ReadFile(snapshot)
+	if err != nil {
+		t.Fatalf("vault snapshot missing credentials: %v", err)
+	}
+	if string(data) != blob {
+		t.Fatalf("snapshot = %q, want %q", data, blob)
+	}
+}
+
+// TestRestorePushesCredentialsIntoKeychain is the switch itself: restoring a
+// profile has to update the keychain, because that is where Claude Code reads
+// from. Restoring the file alone leaves the previous account signed in.
+func TestRestorePushesCredentialsIntoKeychain(t *testing.T) {
+	home, fs := claudeKeychainHome(t)
+	vault := NewVault(filepath.Join(t.TempDir(), "vault"))
+
+	aliceBlob := seedKeychainLogin(t, home, "A", "alice@example.com")
+	if err := vault.Backup(fs, "alice"); err != nil {
+		t.Fatalf("backup alice: %v", err)
+	}
+
+	bobBlob := seedKeychainLogin(t, home, "B", "bob@example.com")
+	if err := vault.Backup(fs, "bob"); err != nil {
+		t.Fatalf("backup bob: %v", err)
+	}
+
+	if got, _ := testutil.KeychainItem(t, keychain.ClaudeService, keychain.CurrentAccount()); got != bobBlob {
+		t.Fatalf("precondition: keychain = %q, want bob", got)
+	}
+
+	if err := vault.Restore(fs, "alice"); err != nil {
+		t.Fatalf("restore alice: %v", err)
+	}
+
+	got, ok := testutil.KeychainItem(t, keychain.ClaudeService, keychain.CurrentAccount())
+	if !ok || got != aliceBlob {
+		t.Fatalf("keychain after restore = %q (ok=%v), want alice's credentials", got, ok)
+	}
+	live, err := os.ReadFile(filepath.Join(home, ".claude", ".credentials.json"))
+	if err != nil || string(live) != aliceBlob {
+		t.Fatalf("live credentials file = %q (err=%v), want alice's credentials", live, err)
+	}
+}
+
+// TestActiveProfileMatchesKeychainAccount checks identity detection, which
+// hashes the credentials file and so saw nothing to compare on a Mac.
+func TestActiveProfileMatchesKeychainAccount(t *testing.T) {
+	home, fs := claudeKeychainHome(t)
+	vault := NewVault(filepath.Join(t.TempDir(), "vault"))
+
+	seedKeychainLogin(t, home, "A", "alice@example.com")
+	if err := vault.Backup(fs, "alice"); err != nil {
+		t.Fatalf("backup alice: %v", err)
+	}
+	seedKeychainLogin(t, home, "B", "bob@example.com")
+	if err := vault.Backup(fs, "bob"); err != nil {
+		t.Fatalf("backup bob: %v", err)
+	}
+
+	active, err := vault.ActiveProfile(fs)
+	if err != nil {
+		t.Fatalf("active profile: %v", err)
+	}
+	if active != "bob" {
+		t.Fatalf("ActiveProfile = %q, want bob", active)
+	}
+}
+
+// TestClearAuthFilesRemovesKeychainItem covers logout: leaving the item behind
+// would let the CLI sign straight back in as the account just cleared.
+func TestClearAuthFilesRemovesKeychainItem(t *testing.T) {
+	home, fs := claudeKeychainHome(t)
+	seedKeychainLogin(t, home, "A", "alice@example.com")
+
+	if !HasAuthFiles(fs) {
+		t.Fatal("precondition: expected a login")
+	}
+	if err := ClearAuthFiles(fs); err != nil {
+		t.Fatalf("clear: %v", err)
+	}
+	if _, ok := testutil.KeychainItem(t, keychain.ClaudeService, keychain.CurrentAccount()); ok {
+		t.Fatal("keychain item survived logout")
+	}
+	if HasAuthFiles(fs) {
+		t.Fatal("HasAuthFiles = true after logout")
+	}
+}

--- a/internal/keychain/claude.go
+++ b/internal/keychain/claude.go
@@ -1,0 +1,143 @@
+package keychain
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ClaudeService is the generic-password service name Claude Code uses for its
+// OAuth credentials on macOS. The account attribute is the login name (see
+// CurrentAccount), and the secret is byte-for-byte the same JSON document that
+// Claude Code writes to ~/.claude/.credentials.json on platforms without a
+// keychain: {"claudeAiOauth":{"accessToken":...,"refreshToken":...}}.
+const ClaudeService = "Claude Code-credentials"
+
+// ClaudeCredentials returns the credential blob currently in the keychain.
+// ok is false when the bridge is unavailable, no item exists, or the item does
+// not hold JSON (a value caam must not copy into a credentials file).
+func ClaudeCredentials() (data []byte, ok bool) {
+	if !Available() {
+		return nil, false
+	}
+	data, err := Get(ClaudeService, CurrentAccount())
+	if err != nil || len(data) == 0 || !json.Valid(data) {
+		return nil, false
+	}
+	return data, true
+}
+
+// MirrorClaudeCredentials copies the keychain item into path, the plaintext
+// credentials file the rest of caam treats as the source of truth (hashing,
+// identity extraction, active-profile detection, expiry checks).
+//
+// The keychain is authoritative on macOS: Claude Code rotates the tokens there
+// in place, so the mirror is rewritten whenever the two differ, and a stale
+// mirror never wins. Returns true when path now matches the keychain.
+func MirrorClaudeCredentials(path string) bool {
+	if path == "" {
+		return false
+	}
+	data, ok := ClaudeCredentials()
+	if !ok {
+		return false
+	}
+	if existing, err := os.ReadFile(path); err == nil && bytesEqualJSON(existing, data) {
+		return true
+	}
+	if err := writeSecretFile(path, data); err != nil {
+		return false
+	}
+	return true
+}
+
+// StoreClaudeCredentials pushes the credentials file at path into the
+// keychain, which is what makes an account switch visible to Claude Code on
+// macOS: restoring the file alone changes nothing, because the CLI reads the
+// keychain first.
+//
+// Returns nil when there is nothing to do (bridge unavailable, no such file,
+// or the file is not JSON), and an error only when the keychain write itself
+// fails — a case the caller must surface, since silently skipping it leaves
+// the previous account live.
+func StoreClaudeCredentials(path string) error {
+	if !Available() || path == "" {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil || len(data) == 0 || !json.Valid(data) {
+		return nil
+	}
+	if current, ok := ClaudeCredentials(); ok && bytesEqualJSON(current, data) {
+		return nil
+	}
+	if err := Set(ClaudeService, CurrentAccount(), data); err != nil {
+		return fmt.Errorf("store claude credentials in macOS keychain: %w", err)
+	}
+	return nil
+}
+
+// ClearClaudeCredentials removes the keychain item (logout). A missing item or
+// an unavailable bridge is not an error.
+func ClearClaudeCredentials() error {
+	if !Available() {
+		return nil
+	}
+	if err := Delete(ClaudeService, CurrentAccount()); err != nil {
+		return fmt.Errorf("clear claude credentials from macOS keychain: %w", err)
+	}
+	return nil
+}
+
+// bytesEqualJSON compares two credential blobs ignoring trailing whitespace,
+// so a mirror that only differs by a trailing newline is not rewritten.
+func bytesEqualJSON(a, b []byte) bool {
+	return string(trimSpace(a)) == string(trimSpace(b))
+}
+
+func trimSpace(b []byte) []byte {
+	start, end := 0, len(b)
+	for start < end && isSpace(b[start]) {
+		start++
+	}
+	for end > start && isSpace(b[end-1]) {
+		end--
+	}
+	return b[start:end]
+}
+
+func isSpace(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r'
+}
+
+// writeSecretFile writes data to path atomically with 0600 permissions.
+func writeSecretFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp(dir, ".caam-cred-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath)
+
+	if err := tmp.Chmod(0600); err != nil {
+		tmp.Close()
+		return err
+	}
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Sync(); err != nil {
+		tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmpPath, path)
+}

--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -1,0 +1,69 @@
+// Package keychain reads and writes generic-password items in the macOS login
+// keychain.
+//
+// Why caam needs it: on macOS, Claude Code does not keep its OAuth tokens in
+// ~/.claude/.credentials.json the way it does on Linux. It stores them in the
+// login keychain as a generic password under the service
+// "Claude Code-credentials", with the account set to the current login name,
+// and only falls back to the plaintext file when the keychain is unreachable.
+// A caam that swaps files alone therefore captures no token on a Mac: `caam
+// backup` writes a vault profile with no .credentials.json, and `caam
+// activate` restores dotfiles the CLI ignores while the keychain quietly
+// re-asserts the previous account.
+//
+// The implementation shells out to /usr/bin/security, which is exactly what
+// Claude Code itself does (`security add-generic-password -U -a ...`), so the
+// items caam writes carry the same ownership and ACL as the ones the CLI
+// writes and neither side triggers an authorization prompt for the other.
+//
+// Every entry point is a no-op returning ErrUnsupported off darwin, so callers
+// can invoke them unconditionally.
+package keychain
+
+import (
+	"errors"
+	"os"
+	"os/user"
+	"strings"
+)
+
+var (
+	// ErrUnsupported is returned when the platform has no keychain, or when
+	// the keychain bridge is switched off with CAAM_KEYCHAIN=0.
+	ErrUnsupported = errors.New("keychain: unsupported on this platform")
+
+	// ErrNotFound is returned when no item matches the service/account pair.
+	ErrNotFound = errors.New("keychain: item not found")
+)
+
+// EnvDisable turns the bridge off when set to a false-y value. The test
+// harness sets it (see internal/testutil), because keychain state is
+// machine-global and would otherwise leak the developer's real tokens into
+// tests that run under an isolated HOME.
+const EnvDisable = "CAAM_KEYCHAIN"
+
+// EnvBin overrides the `security` binary. Tests point it at a stub.
+const EnvBin = "CAAM_KEYCHAIN_BIN"
+
+// disabled reports whether CAAM_KEYCHAIN switches the bridge off.
+func disabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(EnvDisable))) {
+	case "0", "false", "off", "no":
+		return true
+	}
+	return false
+}
+
+// CurrentAccount returns the login name Claude Code uses as the keychain
+// item's account attribute.
+func CurrentAccount() string {
+	if u, err := user.Current(); err == nil && strings.TrimSpace(u.Username) != "" {
+		return u.Username
+	}
+	for _, key := range []string{"USER", "LOGNAME"} {
+		if v := strings.TrimSpace(os.Getenv(key)); v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/keychain/keychain_darwin.go
+++ b/internal/keychain/keychain_darwin.go
@@ -1,0 +1,129 @@
+//go:build darwin
+
+package keychain
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// itemNotFoundExit is errSecItemNotFound, the exit status `security` uses for
+// a search or delete that matched nothing.
+const itemNotFoundExit = 44
+
+// commandTimeout bounds every `security` call. A locked keychain makes the
+// tool wait on a GUI unlock prompt; in a headless or agent context that would
+// hang caam indefinitely, so treat a stall as "keychain unavailable" and let
+// the caller fall back to the plaintext file.
+const commandTimeout = 20 * time.Second
+
+// securityBin resolves the `security` CLI, honouring EnvBin for tests.
+func securityBin() (string, error) {
+	if override := strings.TrimSpace(os.Getenv(EnvBin)); override != "" {
+		return override, nil
+	}
+	path, err := exec.LookPath("security")
+	if err != nil {
+		return "", fmt.Errorf("%w: %v", ErrUnsupported, err)
+	}
+	return path, nil
+}
+
+// Available reports whether keychain access is usable right now: darwin, the
+// `security` CLI on PATH, and the bridge not switched off.
+func Available() bool {
+	if disabled() {
+		return false
+	}
+	_, err := securityBin()
+	return err == nil
+}
+
+func run(args ...string) ([]byte, error) {
+	bin, err := securityBin()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, bin, args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	// `security` prompts on the controlling terminal when the keychain is
+	// locked. Detach stdin so it fails fast instead of blocking on input that
+	// an agent or a script can never supply.
+	cmd.Stdin = nil
+
+	err = cmd.Run()
+	if ctxErr := ctx.Err(); errors.Is(ctxErr, context.DeadlineExceeded) {
+		return nil, fmt.Errorf("security %s: timed out after %s (keychain locked?)", args[0], commandTimeout)
+	}
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == itemNotFoundExit {
+			return nil, ErrNotFound
+		}
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return nil, fmt.Errorf("security %s: %s", args[0], msg)
+	}
+	return stdout.Bytes(), nil
+}
+
+// Get returns the secret stored for service/account, or ErrNotFound.
+func Get(service, account string) ([]byte, error) {
+	if disabled() {
+		return nil, ErrUnsupported
+	}
+	if service == "" || account == "" {
+		return nil, ErrNotFound
+	}
+	out, err := run("find-generic-password", "-s", service, "-a", account, "-w")
+	if err != nil {
+		return nil, err
+	}
+	// -w prints the secret followed by a newline that is not part of it.
+	return bytes.TrimSuffix(out, []byte("\n")), nil
+}
+
+// Set stores data for service/account, replacing any existing item.
+//
+// The secret travels as an argv element, which is visible to `ps` for the
+// lifetime of the call. That is how Claude Code writes the same item, and the
+// `security` CLI offers no way to hand a generic password over a pipe
+// non-interactively.
+func Set(service, account string, data []byte) error {
+	if disabled() {
+		return ErrUnsupported
+	}
+	if service == "" || account == "" {
+		return errors.New("keychain: service and account are required")
+	}
+	_, err := run("add-generic-password", "-U", "-s", service, "-a", account, "-w", string(data))
+	return err
+}
+
+// Delete removes the item for service/account. A missing item is not an error.
+func Delete(service, account string) error {
+	if disabled() {
+		return ErrUnsupported
+	}
+	if service == "" || account == "" {
+		return nil
+	}
+	_, err := run("delete-generic-password", "-s", service, "-a", account)
+	if errors.Is(err, ErrNotFound) {
+		return nil
+	}
+	return err
+}

--- a/internal/keychain/keychain_other.go
+++ b/internal/keychain/keychain_other.go
@@ -1,0 +1,16 @@
+//go:build !darwin
+
+package keychain
+
+// Available is always false off darwin: no other platform caam supports keeps
+// Claude Code credentials outside the filesystem.
+func Available() bool { return false }
+
+// Get is unsupported off darwin.
+func Get(service, account string) ([]byte, error) { return nil, ErrUnsupported }
+
+// Set is unsupported off darwin.
+func Set(service, account string, data []byte) error { return ErrUnsupported }
+
+// Delete is unsupported off darwin.
+func Delete(service, account string) error { return ErrUnsupported }

--- a/internal/keychain/keychain_test.go
+++ b/internal/keychain/keychain_test.go
@@ -1,0 +1,177 @@
+package keychain_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/keychain"
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+const account = "tester"
+
+func TestGetSetDeleteRoundTrip(t *testing.T) {
+	testutil.FakeKeychain(t)
+
+	if _, err := keychain.Get("svc", account); !errors.Is(err, keychain.ErrNotFound) {
+		t.Fatalf("Get on empty keychain = %v, want ErrNotFound", err)
+	}
+
+	if err := keychain.Set("svc", account, []byte(`{"a":1}`)); err != nil {
+		t.Fatalf("Set: %v", err)
+	}
+	got, err := keychain.Get("svc", account)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got) != `{"a":1}` {
+		t.Fatalf("Get = %q, want %q", got, `{"a":1}`)
+	}
+
+	// Set replaces in place rather than creating a second item.
+	if err := keychain.Set("svc", account, []byte(`{"a":2}`)); err != nil {
+		t.Fatalf("Set (update): %v", err)
+	}
+	got, _ = keychain.Get("svc", account)
+	if string(got) != `{"a":2}` {
+		t.Fatalf("after update Get = %q, want %q", got, `{"a":2}`)
+	}
+
+	if err := keychain.Delete("svc", account); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := keychain.Get("svc", account); !errors.Is(err, keychain.ErrNotFound) {
+		t.Fatalf("Get after Delete = %v, want ErrNotFound", err)
+	}
+	// Deleting a missing item is not an error.
+	if err := keychain.Delete("svc", account); err != nil {
+		t.Fatalf("Delete (missing): %v", err)
+	}
+}
+
+func TestDisabledBridgeIsInert(t *testing.T) {
+	testutil.FakeKeychain(t)
+	testutil.SetKeychainItem(t, keychain.ClaudeService, keychain.CurrentAccount(), `{"claudeAiOauth":{"accessToken":"T"}}`)
+
+	t.Setenv(keychain.EnvDisable, "0")
+
+	if keychain.Available() {
+		t.Fatal("Available = true with CAAM_KEYCHAIN=0")
+	}
+	if _, ok := keychain.ClaudeCredentials(); ok {
+		t.Fatal("ClaudeCredentials returned a value with the bridge disabled")
+	}
+	path := filepath.Join(t.TempDir(), ".credentials.json")
+	if keychain.MirrorClaudeCredentials(path) {
+		t.Fatal("MirrorClaudeCredentials succeeded with the bridge disabled")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("disabled bridge wrote %s", path)
+	}
+}
+
+func TestMirrorClaudeCredentials(t *testing.T) {
+	testutil.FakeKeychain(t)
+	path := filepath.Join(t.TempDir(), ".claude", ".credentials.json")
+
+	// Nothing in the keychain: nothing to mirror.
+	if keychain.MirrorClaudeCredentials(path) {
+		t.Fatal("mirrored from an empty keychain")
+	}
+
+	const blob = `{"claudeAiOauth":{"accessToken":"A","refreshToken":"R"}}`
+	testutil.SetKeychainItem(t, keychain.ClaudeService, keychain.CurrentAccount(), blob)
+
+	if !keychain.MirrorClaudeCredentials(path) {
+		t.Fatal("MirrorClaudeCredentials = false, want true")
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read mirror: %v", err)
+	}
+	if string(data) != blob {
+		t.Fatalf("mirror = %q, want %q", data, blob)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat mirror: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Fatalf("mirror mode = %o, want 600", perm)
+	}
+
+	// The keychain wins over a stale file: Claude Code rotates tokens there.
+	const rotated = `{"claudeAiOauth":{"accessToken":"A2","refreshToken":"R2"}}`
+	testutil.SetKeychainItem(t, keychain.ClaudeService, keychain.CurrentAccount(), rotated)
+	if !keychain.MirrorClaudeCredentials(path) {
+		t.Fatal("re-mirror = false, want true")
+	}
+	data, _ = os.ReadFile(path)
+	if string(data) != rotated {
+		t.Fatalf("stale mirror survived: %q", data)
+	}
+}
+
+func TestMirrorRejectsNonJSONItem(t *testing.T) {
+	testutil.FakeKeychain(t)
+	testutil.SetKeychainItem(t, keychain.ClaudeService, keychain.CurrentAccount(), "not json")
+
+	path := filepath.Join(t.TempDir(), ".credentials.json")
+	if keychain.MirrorClaudeCredentials(path) {
+		t.Fatal("mirrored a non-JSON keychain item")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("non-JSON item was written to %s", path)
+	}
+}
+
+func TestStoreAndClearClaudeCredentials(t *testing.T) {
+	testutil.FakeKeychain(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".credentials.json")
+
+	// A missing file is not an error, and stores nothing.
+	if err := keychain.StoreClaudeCredentials(path); err != nil {
+		t.Fatalf("Store (missing file): %v", err)
+	}
+	if _, ok := keychain.ClaudeCredentials(); ok {
+		t.Fatal("Store wrote an item for a missing file")
+	}
+
+	const blob = `{"claudeAiOauth":{"accessToken":"B"}}`
+	if err := os.WriteFile(path, []byte(blob), 0600); err != nil {
+		t.Fatalf("write credentials: %v", err)
+	}
+	if err := keychain.StoreClaudeCredentials(path); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	got, ok := testutil.KeychainItem(t, keychain.ClaudeService, keychain.CurrentAccount())
+	if !ok || got != blob {
+		t.Fatalf("keychain item = %q (ok=%v), want %q", got, ok, blob)
+	}
+
+	if err := keychain.ClearClaudeCredentials(); err != nil {
+		t.Fatalf("Clear: %v", err)
+	}
+	if _, ok := keychain.ClaudeCredentials(); ok {
+		t.Fatal("item survived ClearClaudeCredentials")
+	}
+}
+
+func TestStoreRejectsNonJSONFile(t *testing.T) {
+	testutil.FakeKeychain(t)
+
+	path := filepath.Join(t.TempDir(), ".credentials.json")
+	if err := os.WriteFile(path, []byte("garbage"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := keychain.StoreClaudeCredentials(path); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if _, ok := keychain.ClaudeCredentials(); ok {
+		t.Fatal("Store pushed a non-JSON file into the keychain")
+	}
+}

--- a/internal/keychain/main_test.go
+++ b/internal/keychain/main_test.go
@@ -1,0 +1,16 @@
+package keychain_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/testutil"
+)
+
+// TestMain runs this package's tests under an isolated HOME, which also
+// switches the keychain bridge off by default. Tests that need it opt in via
+// testutil.FakeKeychain, which points `security` at a stub. See
+// testutil.IsolatedMain.
+func TestMain(m *testing.M) {
+	os.Exit(testutil.IsolatedMain(m))
+}

--- a/internal/provider/claude/claude.go
+++ b/internal/provider/claude/claude.go
@@ -41,6 +41,7 @@ import (
 	"time"
 
 	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/browser"
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/keychain"
 	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/passthrough"
 	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/profile"
 	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/provider"
@@ -563,6 +564,10 @@ func (p *Provider) DetectExistingAuth() (*provider.AuthDetection, error) {
 	if err != nil {
 		return nil, fmt.Errorf("get home dir: %w", err)
 	}
+
+	// On macOS the OAuth tokens live in the login keychain, not on disk;
+	// mirror them into the credentials file so the scan below can see them.
+	keychain.MirrorClaudeCredentials(filepath.Join(homeDir, ".claude", ".credentials.json"))
 
 	// Define locations to check
 	locations := []struct {

--- a/internal/testutil/isolate.go
+++ b/internal/testutil/isolate.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/keychain"
 )
 
 // isolatedMarker is exported into the environment by IsolateEnv so that a
@@ -104,11 +106,19 @@ func IsolateEnv() (restore func(), err error) {
 	}
 	remember("PATH")
 	remember("BROWSER")
+	remember(keychain.EnvDisable)
+	remember(keychain.EnvBin)
 	remember(isolatedMarker)
 
 	os.Setenv("HOME", dir)
 	os.Setenv("USERPROFILE", dir)
 	os.Setenv(isolatedMarker, "1")
+	// The macOS keychain is machine-global: an isolated HOME does not contain
+	// it. Leaving the bridge on would let tests read (and rewrite) the
+	// developer's real Claude tokens, so it stays off unless a test opts in by
+	// setting CAAM_KEYCHAIN=1 with CAAM_KEYCHAIN_BIN pointed at a stub.
+	os.Setenv(keychain.EnvDisable, "0")
+	os.Unsetenv(keychain.EnvBin)
 
 	if runtime.GOOS != "windows" {
 		stubDir := filepath.Join(dir, "stub-bin")

--- a/internal/testutil/keychain.go
+++ b/internal/testutil/keychain.go
@@ -1,0 +1,99 @@
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/Dicklesworthstone/coding_agent_account_manager/internal/keychain"
+)
+
+// fakeSecurityScript emulates the subset of /usr/bin/security that
+// internal/keychain drives, backed by one file per item in a temp directory.
+// It reproduces the two behaviours the real tool's callers depend on: `-w`
+// prints the secret followed by a newline, and a missing item exits 44
+// (errSecItemNotFound).
+const fakeSecurityScript = `#!/bin/sh
+dir="$CAAM_TEST_KEYCHAIN_DIR"
+cmd="$1"
+shift
+svc=""
+acct=""
+pw=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -s) svc="$2"; shift 2 ;;
+    -a) acct="$2"; shift 2 ;;
+    -w)
+      if [ "$cmd" = "add-generic-password" ] && [ $# -ge 2 ]; then
+        pw="$2"; shift 2
+      else
+        shift
+      fi
+      ;;
+    *) shift ;;
+  esac
+done
+file="$dir/$(printf '%s' "${svc}__${acct}" | tr '/ ' '__')"
+case "$cmd" in
+  find-generic-password)
+    [ -f "$file" ] || exit 44
+    cat "$file"
+    echo
+    ;;
+  add-generic-password)
+    mkdir -p "$dir"
+    printf '%s' "$pw" > "$file"
+    ;;
+  delete-generic-password)
+    [ -f "$file" ] || exit 44
+    rm -f "$file"
+    ;;
+  *) exit 1 ;;
+esac
+`
+
+// FakeKeychain points internal/keychain at a stub `security` binary backed by
+// a temp directory and switches the bridge on for the duration of the test.
+// It skips on non-darwin, where the bridge is compiled out.
+//
+// Tests need this because the real keychain is machine-global: IsolateEnv
+// disables the bridge outright so no test can read or overwrite the
+// developer's actual Claude Code tokens.
+func FakeKeychain(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS != "darwin" {
+		t.Skip("keychain bridge is darwin-only")
+	}
+
+	dir := t.TempDir()
+	script := filepath.Join(dir, "security")
+	if err := os.WriteFile(script, []byte(fakeSecurityScript), 0700); err != nil {
+		t.Fatalf("write fake security: %v", err)
+	}
+
+	t.Setenv("CAAM_TEST_KEYCHAIN_DIR", filepath.Join(dir, "items"))
+	t.Setenv(keychain.EnvBin, script)
+	t.Setenv(keychain.EnvDisable, "1")
+}
+
+// SetKeychainItem stores a secret in the fake keychain prepared by
+// FakeKeychain.
+func SetKeychainItem(t *testing.T, service, account, secret string) {
+	t.Helper()
+	if err := keychain.Set(service, account, []byte(secret)); err != nil {
+		t.Fatalf("seed keychain item %s/%s: %v", service, account, err)
+	}
+}
+
+// KeychainItem returns the secret stored for service/account, and whether an
+// item exists at all.
+func KeychainItem(t *testing.T, service, account string) (string, bool) {
+	t.Helper()
+	data, err := keychain.Get(service, account)
+	if err != nil {
+		return "", false
+	}
+	return string(data), true
+}


### PR DESCRIPTION
Resolves #98.

## The problem

On macOS, Claude Code keeps its OAuth tokens as a generic password in the login keychain under the service `Claude Code-credentials`, account = login name. It only falls back to `~/.claude/.credentials.json` when the keychain is unreachable. caam had no keychain code, so on a Mac:

- `caam backup claude <name>` wrote a vault profile with no `.credentials.json` — `AllowOptionalOnly` suppressed the missing-required-file error, so it exited 0
- `caam activate` swapped dotfiles the CLI ignores; the keychain kept the previous account signed in, and the switch reported success
- `ls` / `status` showed `EMAIL unknown`, `PLAN unknown`, `🟡 Warning`, all from reading the same absent file
- `shallow-profile create --from-vault claude/<name>` failed with `missing .credentials.json` on every Mac snapshot

## The fix

New `internal/keychain` drives `/usr/bin/security` — the same tool Claude Code itself shells out to (`add-generic-password -U -a "…"` appears in the CLI binary), so items caam writes carry the same ownership and ACL and neither side prompts the other.

The keychain stays authoritative; the credentials file becomes its mirror, which keeps every existing file-shaped code path working untouched:

| path | behavior |
|---|---|
| `Backup`, `HasAuthFiles`, `ActiveProfile`, `DetectExistingAuth` | keychain → `~/.claude/.credentials.json` (0600) before reading |
| `Restore` | vault → file → **keychain**; a failed keychain write is a hard error, not a silent skip |
| `ClearAuthFiles` | deletes the file and the keychain item |

`caam doctor` gained a `claude keychain` check. `CAAM_KEYCHAIN=0` disables the bridge.

Off darwin every entry point is a no-op returning `ErrUnsupported`, so callers stay platform-neutral and Linux behavior is unchanged.

## Shallow / isolated profiles

The keychain is `$HOME`-scoped: under a profile HOME, `security` finds no item and Claude Code falls back to that profile's own `.credentials.json`. Verified by running `claude --print` under a temporary HOME holding only the file — it authenticated. Since vault snapshots now carry real credentials, `shallow-profile create --from-vault` works on macOS for the first time; a seeded lane ran a real `claude --print` end to end.

## Testing

`internal/testutil/isolate.go` sets `CAAM_KEYCHAIN=0`: keychain state is machine-global, so an isolated HOME does not contain it and the bridge would otherwise let tests read and overwrite the developer's real tokens. Tests opt in through `testutil.FakeKeychain`, which points `CAAM_KEYCHAIN_BIN` at a stub `security` reproducing the two behaviors callers depend on — `-w` prints the secret plus a newline, and a missing item exits 44.

New coverage: keychain round-trip and not-found, disabled-bridge inertness, mirror refresh when the keychain rotates, rejection of non-JSON on both sides, and in `internal/authfile` the four bridged paths (keychain-only login detected, backup captures the token, restore pushes it into the keychain, logout removes the item).

`go test ./...` — 54 packages ok.

## Verified on a real Mac

caam 0.1.18 → this build, macOS 24.6.0, Claude Code 2.1.259:

- mirror file sha == keychain item sha, mode 0600
- `caam backup claude <name>` captured the real token into the vault
- in-place update of Claude Code's own keychain item preserved content, no prompt
- status went `🟡 Warning` with no identity → `healthy`, real expiry, `EMAIL`/`PLAN Max` populated

## Notes for review

- The secret travels as an argv element to `security`, briefly visible to `ps`. That is how Claude Code writes the same item, and the CLI offers no way to hand a generic password over a pipe non-interactively — piping to `-w` makes it prompt twice and store an empty value.
- The mirror is a plaintext token file on disk, the same shape and 0600 mode caam already relies on everywhere else.
- CHANGELOG left alone; the `[Unreleased]` section links merged commit SHAs, so it looked like maintainer-curated territory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)